### PR TITLE
Fix incorrect URL construction when RequestURI is in absolute-form

### DIFF
--- a/modsecurity.go
+++ b/modsecurity.go
@@ -250,7 +250,7 @@ func (a *Modsecurity) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		// Don't restore req.Body yet - only create reader when needed
 	}
 
-	url := a.modSecurityUrl + req.RequestURI
+	url := a.modSecurityUrl + req.URL.RequestURI()
 
 	// Create request body reader (nil for methods that ignore body)
 	var bodyReader io.Reader


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p data-start="292" data-end="461">This patch fixes an issue when the incoming HTTP request uses <strong data-start="354" data-end="382">absolute-form RequestURI</strong>, which can happen with HTTP/1.0 clients or when a client behaves like a proxy.</p>
<p data-start="463" data-end="531">The current implementation builds the ModSecurity request URL using:</p>
<pre class="overflow-visible! px-0!" data-start="533" data-end="583"><div class="relative w-full my-4"><div class=""><div class="relative"><div class="h-full min-h-0 min-w-0"><div class="h-full min-h-0 min-w-0"><div class="border border-token-border-light border-radius-3xl corner-superellipse/1.1 rounded-3xl"><div class="h-full w-full border-radius-3xl bg-token-bg-elevated-secondary corner-superellipse/1.1 overflow-clip rounded-3xl lxnfua_clipPathFallback"><div class="pointer-events-none absolute inset-x-4 top-12 bottom-4"><div class="pointer-events-none sticky z-40 shrink-0 z-1!"><div class="sticky bg-token-border-light"></div></div></div><div class=""><div class="relative z-0 flex max-w-full"><div id="code-block-viewer" dir="ltr" class="q9tKkq_viewer cm-editor z-10 light:cm-light dark:cm-light flex h-full w-full flex-col items-stretch ͼ5 ͼj"><div class="cm-scroller"><div class="cm-content q9tKkq_readonly"><span class="ͼe">url</span><span> </span><span class="ͼ8">:=</span><span> </span><span class="ͼe">a</span><span class="ͼ8">.</span><span>modSecurityUrl </span><span class="ͼ8">+</span><span> </span><span class="ͼe">req</span><span class="ͼ8">.</span><span>RequestURI</span></div></div></div></div></div></div></div></div></div><div class=""><div class=""></div></div></div></div></div></pre>
<p data-start="585" data-end="630">However, <code data-start="594" data-end="610">req.RequestURI</code> may contain either:</p>
<ul data-start="632" data-end="810">
<li data-start="632" data-end="687">
<p data-start="634" data-end="687"><strong data-start="634" data-end="649">origin-form</strong> (most common for servers)<br data-start="675" data-end="678">
<code data-start="680" data-end="687">/reg/</code></p>
</li>
<li data-start="689" data-end="810">
<p data-start="691" data-end="810"><strong data-start="691" data-end="708">absolute-form</strong> (allowed by HTTP and commonly used when communicating with proxies)<br data-start="776" data-end="779">
<code data-start="781" data-end="810">http://www.example.com/reg/</code></p>
</li>
</ul>
<p data-start="812" data-end="899">When the request arrives in absolute-form, the plugin generates an invalid URL such as:</p>
<pre class="overflow-visible! px-0!" data-start="901" data-end="951"><div class="relative w-full my-4"><div class=""><div class="relative"><div class="h-full min-h-0 min-w-0"><div class="h-full min-h-0 min-w-0"><div class="border border-token-border-light border-radius-3xl corner-superellipse/1.1 rounded-3xl"><div class="h-full w-full border-radius-3xl bg-token-bg-elevated-secondary corner-superellipse/1.1 overflow-clip rounded-3xl lxnfua_clipPathFallback"><div class="pointer-events-none absolute end-1.5 top-1 z-2 md:end-2 md:top-1"></div><div class="pt-3"><div class="relative z-0 flex max-w-full"><div id="code-block-viewer" dir="ltr" class="q9tKkq_viewer cm-editor z-10 light:cm-light dark:cm-light flex h-full w-full flex-col items-stretch ͼ5 ͼj"><div class="cm-scroller"><div class="cm-content q9tKkq_readonly"><span>http://waf:8080http://www.example.com/reg/</span></div></div></div></div></div></div></div></div></div><div class=""><div class=""></div></div></div></div></div></pre>
<p data-start="953" data-end="1029">This causes the ModSecurity request to fail with DNS resolution errors like:</p>
<pre class="overflow-visible! px-0!" data-start="1031" data-end="1072"><div class="relative w-full my-4"><div class=""><div class="relative"><div class="h-full min-h-0 min-w-0"><div class="h-full min-h-0 min-w-0"><div class="border border-token-border-light border-radius-3xl corner-superellipse/1.1 rounded-3xl"><div class="h-full w-full border-radius-3xl bg-token-bg-elevated-secondary corner-superellipse/1.1 overflow-clip rounded-3xl lxnfua_clipPathFallback"><div class="pointer-events-none absolute end-1.5 top-1 z-2 md:end-2 md:top-1"></div><div class="pt-3"><div class="relative z-0 flex max-w-full"><div id="code-block-viewer" dir="ltr" class="q9tKkq_viewer cm-editor z-10 light:cm-light dark:cm-light flex h-full w-full flex-col items-stretch ͼ5 ͼj"><div class="cm-scroller"><div class="cm-content q9tKkq_readonly"><span>lookup waf:8080http: no such host</span></div></div></div></div></div></div></div></div></div><div class=""><div class=""></div></div></div></div></div></pre>
<p data-start="1074" data-end="1086"><strong data-start="1074" data-end="1086">Solution</strong></p>
<p data-start="1088" data-end="1236">Use the parsed URL provided by Go's HTTP server instead of <code data-start="1147" data-end="1159">RequestURI</code>.<br data-start="1160" data-end="1163">
<code data-start="1163" data-end="1185">req.URL.RequestURI()</code> always returns a normalized <strong data-start="1214" data-end="1230">path + query</strong> form.</p>
<pre class="overflow-visible! px-0!" data-start="1238" data-end="1294"><div class="relative w-full my-4"><div class=""><div class="relative"><div class="h-full min-h-0 min-w-0"><div class="h-full min-h-0 min-w-0"><div class="border border-token-border-light border-radius-3xl corner-superellipse/1.1 rounded-3xl"><div class="h-full w-full border-radius-3xl bg-token-bg-elevated-secondary corner-superellipse/1.1 overflow-clip rounded-3xl lxnfua_clipPathFallback"><div class="pointer-events-none absolute inset-x-4 top-12 bottom-4"><div class="pointer-events-none sticky z-40 shrink-0 z-1!"><div class="sticky bg-token-border-light"></div></div></div><div class=""><div class="relative z-0 flex max-w-full"><div id="code-block-viewer" dir="ltr" class="q9tKkq_viewer cm-editor z-10 light:cm-light dark:cm-light flex h-full w-full flex-col items-stretch ͼ5 ͼj"><div class="cm-scroller"><div class="cm-content q9tKkq_readonly"><span class="ͼe">url</span><span> </span><span class="ͼ8">:=</span><span> </span><span class="ͼe">a</span><span class="ͼ8">.</span><span>modSecurityUrl </span><span class="ͼ8">+</span><span> </span><span class="ͼe">req</span><span class="ͼ8">.</span><span>URL</span><span class="ͼ8">.</span><span>RequestURI()</span></div></div></div></div></div></div></div></div></div><div class=""><div class=""></div></div></div></div></div></pre>
<p data-start="1296" data-end="1357">This ensures that both request formats are handled correctly:</p>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex flex-col-reverse w-fit">
Incoming request | Generated URL
-- | --
POST /reg/ HTTP/1.1 | http://waf:8080/reg/
POST http://example.com/reg/ HTTP/1.0 | http://waf:8080/reg/

</div></div>
<p data-start="1527" data-end="1537"><strong data-start="1527" data-end="1537">Impact</strong></p>
<ul data-start="1539" data-end="1718">
<li data-start="1539" data-end="1602">
<p data-start="1541" data-end="1602">Fixes failures when clients send <strong data-start="1574" data-end="1602">absolute-form RequestURI</strong></p>
</li>
<li data-start="1603" data-end="1653">
<p data-start="1605" data-end="1653">Improves compatibility with <strong data-start="1633" data-end="1653">HTTP/1.0 clients</strong></p>
</li>
<li data-start="1654" data-end="1718">
<p data-start="1656" data-end="1718">Keeps existing behavior unchanged for normal HTTP/1.1 requests</p>
</li>
</ul>
<p data-start="1720" data-end="1731"><strong data-start="1720" data-end="1731">Testing</strong></p>
<p data-start="1733" data-end="1747">Verified with:</p>
<ul data-start="1749" data-end="1858">
<li data-start="1749" data-end="1792">
<p data-start="1751" data-end="1792">Standard HTTP/1.1 requests (<code data-start="1779" data-end="1791">POST /path</code>)</p>
</li>
<li data-start="1793" data-end="1858">
<p data-start="1795" data-end="1858">HTTP/1.0 requests using absolute-form (<code data-start="1834" data-end="1857">POST http://host/path</code>)</p>
</li>
</ul>
<p data-start="1860" data-end="1920">Both cases now correctly forward the request to ModSecurity.</p><!--EndFragment-->
</body>
</html>