### PR TITLE
✨ feat(crs): inspect-only sidecar overlay without a dummy hop

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,19 +14,45 @@ jobs:
   integration-tests:
     name: Integration Tests (${{ matrix.stack }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
+    env:
+      INTEGRATION_STACK: ${{ matrix.stack }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - stack: apache
+          - stack: apache-whoami
             compose_file: docker-compose.test.yml
-          - stack: nginx
+            override_file: ""
+          - stack: nginx-whoami
             compose_file: docker-compose.test.nginx.yml
+            override_file: ""
+          - stack: apache-drain
+            compose_file: docker-compose.test.yml
+            override_file: docker-compose.test.apache-drain.yml
+          - stack: nginx-drain
+            compose_file: docker-compose.test.nginx.yml
+            override_file: docker-compose.test.nginx-drain.yml
 
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+
+    - name: Install bombardier
+      run: go install github.com/codesenberg/bombardier@latest
+
+    - name: Set compose args
+      run: |
+        ARGS="-f ${{ matrix.compose_file }}"
+        if [ -n "${{ matrix.override_file }}" ]; then
+          ARGS="$ARGS -f ${{ matrix.override_file }}"
+        fi
+        echo "COMPOSE_ARGS=$ARGS" >> "$GITHUB_ENV"
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -59,25 +85,33 @@ jobs:
           echo "❌ ${{ matrix.compose_file }} not found"
           exit 1
         fi
-        echo "✅ Docker Compose test file found"
+        if [ -n "${{ matrix.override_file }}" ] && [ ! -f "${{ matrix.override_file }}" ]; then
+          echo "❌ ${{ matrix.override_file }} not found"
+          exit 1
+        fi
+        echo "✅ Docker Compose test file(s) found"
         
         # Validate Docker Compose file
-        docker compose -f ${{ matrix.compose_file }} config
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS config
 
     - name: Pull Docker Images
       run: |
         echo "🔄 Pulling required Docker images..."
-        docker compose -f ${{ matrix.compose_file }} pull
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS pull
         echo "✅ Docker images pulled successfully"
 
     - name: Start Test Services
       run: |
         echo "🔄 Starting test services..."
-        docker compose -f ${{ matrix.compose_file }} up -d
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS up -d
         echo "✅ Test services started"
         
         echo "📋 Running containers:"
-        docker compose -f ${{ matrix.compose_file }} ps
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS ps
 
     - name: Wait for Services to be Ready
       shell: pwsh
@@ -141,6 +175,7 @@ jobs:
       shell: pwsh
       run: |
         Write-Host "🧪 Running Pester integration tests..." -ForegroundColor Cyan
+        Write-Host "INTEGRATION_STACK=$env:INTEGRATION_STACK" -ForegroundColor Gray
         
         # Import Pester module
         Import-Module Pester -Force
@@ -174,34 +209,41 @@ jobs:
       if: failure()
       run: |
         echo "📋 Container Status:"
-        docker compose -f ${{ matrix.compose_file }} ps
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS ps
         
         echo ""
         echo "📝 Service Logs:"
         echo "==================== Traefik Logs ===================="
-        docker compose -f ${{ matrix.compose_file }} logs traefik --tail=50
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS logs traefik --tail=50
         
         echo ""
         echo "==================== WAF Logs ===================="
-        docker compose -f ${{ matrix.compose_file }} logs waf --tail=50
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS logs waf --tail=50
         
         echo ""
         echo "==================== Protected Service Logs ===================="
-        docker compose -f ${{ matrix.compose_file }} logs whoami-protected --tail=50
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS logs whoami-protected --tail=50
         
         echo ""
         echo "==================== Bypass Service Logs ===================="
-        docker compose -f ${{ matrix.compose_file }} logs whoami-bypass --tail=50
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS logs whoami-bypass --tail=50
 
         echo ""
         echo "==================== WebSocket echo Logs ===================="
-        docker compose -f ${{ matrix.compose_file }} logs echo-ws --tail=50
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS logs echo-ws --tail=50
 
     - name: Cleanup Test Environment
       if: always()
       run: |
         echo "🧹 Cleaning up test environment..."
-        docker compose -f ${{ matrix.compose_file }} down -v --remove-orphans
+        # shellcheck disable=SC2086
+        docker compose $COMPOSE_ARGS down -v --remove-orphans
         echo "✅ Cleanup completed"
 
   # Additional job to test the PowerShell runner script
@@ -245,6 +287,11 @@ jobs:
         $requiredFiles = @(
             "./docker-compose.test.yml",
             "./docker-compose.test.nginx.yml",
+            "./docker-compose.test.apache-drain.yml",
+            "./docker-compose.test.nginx-drain.yml",
+            "./crs-apache/httpd-vhosts.conf",
+            "./crs-apache/httpd-vhosts.drain.conf",
+            "./crs-nginx/drain-origin.conf",
             "./scripts/integration-tests.Tests.ps1"
         )
         
@@ -258,8 +305,10 @@ jobs:
         }
         
         Write-Host "✅ All required files are present" -ForegroundColor Green
-    - name: Validate both Compose files
+    - name: Validate all Compose stacks
       run: |
         docker compose -f docker-compose.test.yml config >/dev/null
         docker compose -f docker-compose.test.nginx.yml config >/dev/null
-        echo "✅ Both compose files validate"
+        docker compose -f docker-compose.test.yml -f docker-compose.test.apache-drain.yml config >/dev/null
+        docker compose -f docker-compose.test.nginx.yml -f docker-compose.test.nginx-drain.yml config >/dev/null
+        echo "✅ All four compose stacks validate"

--- a/README.md
+++ b/README.md
@@ -57,16 +57,15 @@ See [docker-compose.yml](docker-compose.yml)
 
 ## How it works
 
-This is a very simple plugin that proxies the query to the owasp/modsecurity apache container.
-
 The plugin classifies the sidecar HTTP status:
 
 - **2xx** — allow: write `ok` on `modSecurityStatusRequestHeader` when that name is set, then forward the request to the real service.
 - **3xx / 4xx** — security block: copy the sidecar response to the client. When `modSecurityStatusRequestHeader` is set, write `blocked`.
 - **5xx** — WAF failure, not a block: set `modSecurityStatusRequestHeader` to `error` when configured, count a health-tracker failure, then fail-open or return 502. The sidecar 5xx body is not forwarded.
 
-The *dummy* service is created so the waf container forward the request to a service and respond with 200 OK all the
-time.
+This is a **shadow WAF**. The sidecar inspects a copy of the request. On allow it answers HTTP 200; Traefik `next` is the real app. Demo compose (`docker-compose.yml`) uses an inspect-only Apache overlay (`crs-apache/httpd-vhosts.drain.conf`) so CRS does not reverse-proxy to a dummy origin.
+
+Integration tests keep **four** stacks so dummy vs drain can be compared: Apache+whoami, nginx+whoami, Apache+drain, nginx+drain. Whoami stacks still run unlabeled `dummy` as `BACKEND`. See `./Test-Integration.ps1 -Stack` / `-AllStacks`.
 
 ## Trust this middleware (client IP in WAF logs)
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A Traefik plugin that integrates with [OWASP ModSecurity Core Rule Set (CRS)](ht
 
 - [Demo](#demo)
 - [Usage (docker-compose.yml)](#usage-docker-composeyml)
+- [Architecture](#architecture)
 - [How it works](#how-it-works)
 - [Trust this middleware (client IP in WAF logs)](#trust-this-middleware-client-ip-in-waf-logs)
 - [Testing](#-testing)
@@ -55,17 +56,45 @@ See [docker-compose.yml](docker-compose.yml)
    owasp/modsecurity
 4. You can you bypass the WAF and check attacks at http://localhost/bypass?test=../etc
 
+## Architecture
+
+Every request goes through Traefik. This plugin sends a **copy** to the WAF. If the WAF allows it, Traefik forwards the original request to **your** application. If the WAF blocks it, the client gets that block and your app is never called.
+
+The `whoami` containers in the demo are only sample websites. Swap them for your real services.
+
+```mermaid
+flowchart LR
+  Client --> Traefik
+  Traefik -->|"copy"| WAF[WAF]
+  Traefik -->|"if allowed"| App[Your application]
+  WAF -.-> Dummy["dummy whoami\noptional"]
+```
+
+| Box | What it is |
+| --- | --- |
+| Traefik | Reverse proxy. Runs this plugin. |
+| WAF | ModSecurity CRS container. Looks at the copy and says allow or block. |
+| Your application | The real site or API. Demo uses `whoami` as a placeholder. |
+| dummy whoami | **Optional.** An extra dummy site so the WAF image has something to talk to. It is **not** your application. The demo does not use it. |
+
+### What to expect (speed)
+
+Treat them as a ballpark, not a promise.
+
+| Setup | GET | POST |
+| --- | --- | --- |
+| Apache + dummy whoami | ~5000 req/s (10 ms) | ~1150 req/s (43 ms) |
+| Apache, no dummy | ~5200 req/s (10 ms) | ~1350 req/s (37 ms) |
+| nginx + dummy whoami | ~4000 req/s (13 ms) | ~1950 req/s (26 ms) |
+| nginx, no dummy | ~3600 req/s (14 ms) | ~2550 req/s (20 ms) |
+
 ## How it works
 
-The plugin classifies the sidecar HTTP status:
+The plugin classifies the sidecar HTTP status (see [Architecture](#architecture) for the service layout):
 
 - **2xx** — allow: write `ok` on `modSecurityStatusRequestHeader` when that name is set, then forward the request to the real service.
 - **3xx / 4xx** — security block: copy the sidecar response to the client. When `modSecurityStatusRequestHeader` is set, write `blocked`.
 - **5xx** — WAF failure, not a block: set `modSecurityStatusRequestHeader` to `error` when configured, count a health-tracker failure, then fail-open or return 502. The sidecar 5xx body is not forwarded.
-
-This is a **shadow WAF**. The sidecar inspects a copy of the request. On allow it answers HTTP 200; Traefik `next` is the real app. Demo compose (`docker-compose.yml`) uses an inspect-only Apache overlay (`crs-apache/httpd-vhosts.drain.conf`) so CRS does not reverse-proxy to a dummy origin.
-
-Integration tests keep **four** stacks so dummy vs drain can be compared: Apache+whoami, nginx+whoami, Apache+drain, nginx+drain. Whoami stacks still run unlabeled `dummy` as `BACKEND`. See `./Test-Integration.ps1 -Stack` / `-AllStacks`.
 
 ## Trust this middleware (client IP in WAF logs)
 

--- a/Test-Integration.ps1
+++ b/Test-Integration.ps1
@@ -8,6 +8,12 @@
     This script starts the Docker Compose services, waits for them to be ready,
     runs the Pester integration tests, and then cleans up the services.
 
+    Four stacks (CRS engine × origin):
+      apache-whoami  docker-compose.test.yml
+      nginx-whoami   docker-compose.test.nginx.yml
+      apache-drain   docker-compose.test.yml + docker-compose.test.apache-drain.yml
+      nginx-drain    docker-compose.test.nginx.yml + docker-compose.test.nginx-drain.yml
+
 .PARAMETER SkipDockerCleanup
     Skip stopping Docker services after tests complete (useful for debugging)
 
@@ -15,26 +21,32 @@
     Skip waiting for services to be ready (assumes they're already running)
 
 .PARAMETER TestPath
-    Path to the Pester test file (defaults to ./scripts/integration-tests.Tests.ps1)
+    Path to the Pester test file (defaults to ./scripts/*.Tests.ps1)
 
 .PARAMETER ComposeFile
-    Path to the Docker Compose file (defaults to ./docker-compose.test.yml)
+    Path to a single Docker Compose file (ignored when -Stack or -AllStacks is set)
+
+.PARAMETER Stack
+    Named stack: apache-whoami, nginx-whoami, apache-drain, nginx-drain
+
+.PARAMETER AllStacks
+    Run the four stacks in sequence (compose down between each)
 
 .EXAMPLE
     ./Test-Integration.ps1
-    Runs the full integration test suite
+    Apache + dummy whoami origin (default)
 
 .EXAMPLE
-    ./Test-Integration.ps1 -SkipDockerCleanup
-    Runs tests but leaves Docker services running for debugging
+    ./Test-Integration.ps1 -Stack apache-drain
+    Apache inspect-only drain origin
 
 .EXAMPLE
-    ./Test-Integration.ps1 -SkipWait
-    Runs tests assuming services are already running
+    ./Test-Integration.ps1 -AllStacks
+    All four stacks, including bombardier benches when bombardier is installed
 
 .EXAMPLE
     ./Test-Integration.ps1 -ComposeFile ./docker-compose.test.nginx.yml
-    Runs the same suite against the nginx CRS reference stack
+    Same as -Stack nginx-whoami
 #>
 
 [CmdletBinding()]
@@ -43,6 +55,9 @@ param(
     [switch]$SkipWait,
     [string]$TestPath = "./scripts/*.Tests.ps1",
     [string]$ComposeFile = "./docker-compose.test.yml",
+    [ValidateSet('apache-whoami', 'nginx-whoami', 'apache-drain', 'nginx-drain')]
+    [string]$Stack,
+    [switch]$AllStacks,
     # Pester filter options (Pester v5)
     # - FullName supports wildcards and matches Describe/Context/It names
     [string]$PesterFullNameFilter,
@@ -51,6 +66,20 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+function Get-IntegrationStackComposeFiles {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('apache-whoami', 'nginx-whoami', 'apache-drain', 'nginx-drain')]
+        [string]$Stack
+    )
+    switch ($Stack) {
+        'apache-whoami' { @('./docker-compose.test.yml') }
+        'nginx-whoami' { @('./docker-compose.test.nginx.yml') }
+        'apache-drain' { @('./docker-compose.test.yml', './docker-compose.test.apache-drain.yml') }
+        'nginx-drain' { @('./docker-compose.test.nginx.yml', './docker-compose.test.nginx-drain.yml') }
+    }
+}
 
 # Colors for output
 $Colors = @{
@@ -79,6 +108,25 @@ function Write-Warning {
 function Write-Error {
     param([string]$Message)
     Write-Host "❌ $Message" -ForegroundColor $Colors.Error
+}
+
+function Get-ComposeDashF {
+    param([string[]]$Files)
+    $out = @()
+    foreach ($f in $Files) {
+        $out += '-f'
+        $out += $f
+    }
+    return $out
+}
+
+function Get-StackNameFromComposeFiles {
+    param([string[]]$Files)
+    $joined = ($Files -join ' ')
+    if ($joined -match 'apache-drain') { return 'apache-drain' }
+    if ($joined -match 'nginx-drain') { return 'nginx-drain' }
+    if ($joined -match 'nginx') { return 'nginx-whoami' }
+    return 'apache-whoami'
 }
 
 function Test-ServiceHealth {
@@ -135,15 +183,16 @@ function Test-DockerCompose {
 }
 
 function Start-TestServices {
-    param([string]$ComposeFile)
+    param([string[]]$ComposeFiles)
     
-    Write-Step "Starting Docker Compose services using $ComposeFile..."
+    $dashF = Get-ComposeDashF $ComposeFiles
+    Write-Step "Starting Docker Compose services using $($ComposeFiles -join ', ')..."
     try {
         # Stop any existing containers first
-        docker compose -f $ComposeFile down -v --remove-orphans 2>$null | Out-Null
+        docker compose @dashF down -v --remove-orphans 2>$null | Out-Null
         
         # Start fresh containers
-        $output = docker compose -f $ComposeFile up -d 2>&1
+        $output = docker compose @dashF up -d 2>&1
         if ($LASTEXITCODE -ne 0) {
             Write-Host "Docker Compose Output:" -ForegroundColor $Colors.Gray
             Write-Host $output -ForegroundColor $Colors.Gray
@@ -153,7 +202,7 @@ function Start-TestServices {
         
         # Show running containers for verification
         Write-Host "`nRunning containers:" -ForegroundColor $Colors.Info
-        docker compose -f $ComposeFile ps
+        docker compose @dashF ps | Out-Host
         
     }
     catch {
@@ -163,6 +212,8 @@ function Start-TestServices {
 }
 
 function Wait-ForAllServices {
+    param([string[]]$ComposeFiles)
+
     Write-Step "Waiting for all services to become ready..."
     
     $services = @(
@@ -179,12 +230,106 @@ function Wait-ForAllServices {
     if ($servicesReady -contains $false) {
         Write-Error "One or more services failed to start properly"
         Write-Host "`nContainer logs for debugging:" -ForegroundColor $Colors.Warning
-        docker compose -f $ComposeFile logs --tail=20
+        $dashF = Get-ComposeDashF $ComposeFiles
+        docker compose @dashF logs --tail=20 | Out-Host
         return $false
     }
     
     Write-Success "All services are ready for testing!"
     return $true
+}
+
+function Invoke-IntegrationStack {
+    param(
+        [string[]]$ComposeFiles,
+        [string]$StackName
+    )
+
+    $code = 1
+    foreach ($f in $ComposeFiles) {
+        if (-not (Test-Path -LiteralPath $f)) {
+            Write-Error "Docker Compose file not found: $f"
+            return 1
+        }
+    }
+
+    $env:INTEGRATION_STACK = $StackName
+    Write-Host ""
+    Write-Host "Stack: $StackName" -ForegroundColor $Colors.Info
+    Write-Host "Compose: $($ComposeFiles -join ', ')" -ForegroundColor $Colors.Gray
+
+    try {
+        Start-TestServices -ComposeFiles $ComposeFiles
+
+        $hasPesterFilters = [bool]$PesterFullNameFilter -or ($PesterTagFilter -and $PesterTagFilter.Count -gt 0)
+        if (-not $SkipWait) {
+            if ($hasPesterFilters) {
+                Write-Warning "Pester filters detected; skipping runner-level readiness checks (tests will wait for their own required services)"
+            } else {
+                if (-not (Wait-ForAllServices -ComposeFiles $ComposeFiles)) {
+                    return 1
+                }
+            }
+        } else {
+            Write-Warning "Skipping service readiness check (assuming services are already running)"
+        }
+
+        Write-Step "Running Pester integration tests..."
+        Write-Host ""
+    
+        $pesterConfig = New-PesterConfiguration
+        $pesterConfig.Run.Path = $TestPath
+        $pesterConfig.Output.Verbosity = 'Detailed'
+        $pesterConfig.Run.Exit = $false
+        $pesterConfig.Run.PassThru = $true
+
+        if ($PesterFullNameFilter) {
+            $pesterConfig.Filter.FullName = $PesterFullNameFilter
+        }
+        if ($PesterTagFilter -and $PesterTagFilter.Count -gt 0) {
+            $pesterConfig.Filter.Tag = $PesterTagFilter
+        }
+        
+        $result = Invoke-Pester -Configuration $pesterConfig
+        
+        Write-Host ""
+        if ($result -and $result.FailedCount -eq 0) {
+            Write-Success "All integration tests passed for $StackName"
+            Write-Host "📊 Test Summary: $($result.PassedCount) passed, $($result.FailedCount) failed, $($result.SkippedCount) skipped" -ForegroundColor $Colors.Info
+            $code = 0
+        } elseif ($result) {
+            Write-Error "$($result.FailedCount) test(s) failed out of $($result.TotalCount) total tests ($StackName)"
+            Write-Host "📊 Test Summary: $($result.PassedCount) passed, $($result.FailedCount) failed, $($result.SkippedCount) skipped" -ForegroundColor $Colors.Warning
+            $code = 1
+        } else {
+            Write-Warning "Could not determine test results"
+            $code = 1
+        }
+    }
+    catch {
+        Write-Error "Failed to run Pester tests: $($_.Exception.Message)"
+        $code = 1
+    }
+    finally {
+        if (-not $SkipDockerCleanup) {
+            Write-Step "Cleaning up Docker services ($StackName)..."
+            try {
+                $dashF = Get-ComposeDashF $ComposeFiles
+                docker compose @dashF down -v --remove-orphans 2>$null | Out-Null
+                Write-Success "Docker services stopped and cleaned up"
+            }
+            catch {
+                Write-Warning "Failed to clean up Docker services: $($_.Exception.Message)"
+            }
+        } else {
+            Write-Warning "Skipping Docker cleanup (services left running for debugging)"
+            $dashFDisplay = (Get-ComposeDashF $ComposeFiles) -join ' '
+            Write-Host "To manually stop services, run: docker compose $dashFDisplay down -v" -ForegroundColor $Colors.Gray
+            Write-Host "To view logs, run: docker compose $dashFDisplay logs" -ForegroundColor $Colors.Gray
+        }
+    }
+
+    return $code
 }
 
 # Main execution
@@ -195,15 +340,17 @@ try {
     Write-Host "=====================================================" -ForegroundColor $Colors.Info
     Write-Host ""
 
-    # Verify files exist
-    if (-not (Test-Path $ComposeFile)) {
-        Write-Error "Docker Compose file not found: $ComposeFile"
+    if ($AllStacks -and $Stack) {
+        Write-Error "Use either -Stack or -AllStacks, not both"
         exit 1
     }
     
-    if (-not (Test-Path $TestPath)) {
-        Write-Error "Test file not found: $TestPath"
-        exit 1
+    if (-not (Test-Path $TestPath) -and -not (Get-Item $TestPath -ErrorAction SilentlyContinue)) {
+        $matches = @(Get-Item $TestPath -ErrorAction SilentlyContinue)
+        if ($matches.Count -eq 0) {
+            Write-Error "Test file not found: $TestPath"
+            exit 1
+        }
     }
 
     # Check if Pester is available
@@ -231,92 +378,42 @@ try {
         exit 1
     }
 
-    # Start Docker services
-    Start-TestServices -ComposeFile $ComposeFile
-
-    $hasPesterFilters = [bool]$PesterFullNameFilter -or ($PesterTagFilter -and $PesterTagFilter.Count -gt 0)
-    if (-not $SkipWait) {
-        if ($hasPesterFilters) {
-            Write-Warning "Pester filters detected; skipping runner-level readiness checks (tests will wait for their own required services)"
-        } else {
-            # Wait for services to be ready (legacy pre-flight)
-            if (-not (Wait-ForAllServices)) {
-                exit 1
-            }
+    $runs = @()
+    if ($AllStacks) {
+        foreach ($name in @('apache-whoami', 'nginx-whoami', 'apache-drain', 'nginx-drain')) {
+            $runs += @{ Name = $name; Files = @(Get-IntegrationStackComposeFiles -Stack $name) }
         }
+    } elseif ($Stack) {
+        $runs += @{ Name = $Stack; Files = @(Get-IntegrationStackComposeFiles -Stack $Stack) }
     } else {
-        Write-Warning "Skipping service readiness check (assuming services are already running)"
+        $files = @($ComposeFile)
+        $runs += @{ Name = (Get-StackNameFromComposeFiles -Files $files); Files = $files }
     }
 
-    # Run Pester tests
-    Write-Step "Running Pester integration tests..."
-    Write-Host ""
-    
-    try {
-        $pesterConfig = New-PesterConfiguration
-        $pesterConfig.Run.Path = $TestPath
-        $pesterConfig.Output.Verbosity = 'Detailed'
-        $pesterConfig.Run.Exit = $false
-        $pesterConfig.Run.PassThru = $true
-
-        if ($PesterFullNameFilter) {
-            $pesterConfig.Filter.FullName = $PesterFullNameFilter
-        }
-        if ($PesterTagFilter -and $PesterTagFilter.Count -gt 0) {
-            $pesterConfig.Filter.Tag = $PesterTagFilter
-        }
-        
-        # Run tests with timeout protection
-        $result = Invoke-Pester -Configuration $pesterConfig
-        
-        Write-Host ""
-        if ($result -and $result.FailedCount -eq 0) {
-            Write-Success "All integration tests passed! 🎉"
-            Write-Host "📊 Test Summary: $($result.PassedCount) passed, $($result.FailedCount) failed, $($result.SkippedCount) skipped" -ForegroundColor $Colors.Info
-            $exitCode = 0
-        } elseif ($result) {
-            Write-Error "$($result.FailedCount) test(s) failed out of $($result.TotalCount) total tests"
-            Write-Host "📊 Test Summary: $($result.PassedCount) passed, $($result.FailedCount) failed, $($result.SkippedCount) skipped" -ForegroundColor $Colors.Warning
-            $exitCode = 1
-        } else {
-            Write-Warning "Could not determine test results"
+    $failedStacks = @()
+    foreach ($run in $runs) {
+        $code = [int](@(Invoke-IntegrationStack -ComposeFiles $run.Files -StackName $run.Name)[-1])
+        if ($code -ne 0) {
+            $failedStacks += $run.Name
             $exitCode = 1
         }
     }
-    catch {
-        Write-Error "Failed to run Pester tests: $($_.Exception.Message)"
-        $exitCode = 1
+    if ($failedStacks.Count -gt 0) {
+        Write-Error "Failed stacks: $($failedStacks -join ', ')"
     }
 }
 catch {
     Write-Error "Unexpected error: $($_.Exception.Message)"
     $exitCode = 1
 }
-finally {
-    # Cleanup Docker services
-    if (-not $SkipDockerCleanup) {
-        Write-Step "Cleaning up Docker services..."
-        try {
-            docker compose -f $ComposeFile down -v --remove-orphans 2>$null
-            Write-Success "Docker services stopped and cleaned up"
-        }
-        catch {
-            Write-Warning "Failed to clean up Docker services: $($_.Exception.Message)"
-        }
-    } else {
-        Write-Warning "Skipping Docker cleanup (services left running for debugging)"
-        Write-Host "To manually stop services, run: docker compose -f $ComposeFile down -v" -ForegroundColor $Colors.Gray
-        Write-Host "To view logs, run: docker compose -f $ComposeFile logs" -ForegroundColor $Colors.Gray
-    }
-    
-    Write-Host ""
-    Write-Host "=====================================================" -ForegroundColor $Colors.Info
-    if ($exitCode -eq 0) {
-        Write-Host "🏁 Integration tests completed successfully!" -ForegroundColor $Colors.Success
-    } else {
-        Write-Host "🏁 Integration tests completed with failures!" -ForegroundColor $Colors.Error
-    }
-    Write-Host ""
+
+Write-Host ""
+Write-Host "=====================================================" -ForegroundColor $Colors.Info
+if ($exitCode -eq 0) {
+    Write-Host "🏁 Integration tests completed successfully!" -ForegroundColor $Colors.Success
+} else {
+    Write-Host "🏁 Integration tests completed with failures!" -ForegroundColor $Colors.Error
 }
+Write-Host ""
 
 exit $exitCode

--- a/crs-apache/httpd-vhosts.drain.conf
+++ b/crs-apache/httpd-vhosts.drain.conf
@@ -1,0 +1,50 @@
+# Inspect-only overlay for owasp/modsecurity-crs:4.3.0-apache-alpine-202406090906.
+# After CRS request phases, answer HTTP 200 with the image /healthz rewrite
+# pattern. No ProxyPass to dummy. Traefik next is the application.
+# Unset Range/If-Range early so a tiny 200 is not sidecar 416 (plugin copies 4xx).
+# That pin hardcodes RemoteIPHeader X-Forwarded-For; REMOTEIP_HEADER is ignored.
+# Keep ${ENV} placeholders — Apache expands them.
+
+# Apache VirtualHost configuration for both HTTP and SSL
+
+Mutex ${MUTEX}
+
+RemoteIPHeader X-Real-IP
+RemoteIPInternalProxy ${REMOTEIP_INT_PROXY}
+
+RequestHeader set X-Forwarded-Proto "${REQ_HEADER_FORWARDED_PROTO}"
+RequestHeader set X-Real-IP %{REMOTE_ADDR}s
+RequestHeader set X-Unique-ID %{UNIQUE_ID}e
+RequestHeader unset Range early
+RequestHeader unset If-Range early
+
+ServerName ${SERVER_NAME}
+ServerAdmin ${SERVER_ADMIN}
+
+SSLProxyEngine ${PROXY_SSL}
+SSLProxyVerify ${PROXY_SSL_VERIFY}
+SSLProxyCheckPeerName ${PROXY_SSL_CHECK_PEER_NAME}
+SSLProxyCACertificateFile ${PROXY_SSL_CA_CERT}
+
+UseCanonicalName on
+
+<Location />
+    RewriteEngine On
+    RewriteRule .* - [R=200,L]
+    ErrorDocument 200 "OK"
+    ProxyPass !
+</Location>
+
+<VirtualHost *:${PORT}>
+    RewriteEngine On
+    RewriteCond %{REQUEST_URI} !^/\.well\-known/acme\-challenge/
+    RewriteCond %{ENV:APACHE_ALWAYS_TLS_REDIRECT} on
+    RewriteRule ^(.*)$ https://%{SERVER_NAME}:${SSL_PORT}$1 [L,R=301]
+</VirtualHost>
+
+<VirtualHost *:${SSL_PORT}>
+  Protocols ${H2_PROTOCOLS}
+  SSLEngine ${SSL_ENGINE}
+  SSLCertificateFile ${SSL_CERT}
+  SSLCertificateKeyFile ${SSL_CERT_KEY}
+</VirtualHost>

--- a/crs-nginx/drain-origin.conf
+++ b/crs-nginx/drain-origin.conf
@@ -1,0 +1,15 @@
+# Loopback origin after CRS request phases on owasp/modsecurity-crs:4.3.0-nginx.
+# Mount next to zz-realip.conf. Point BACKEND at http://127.0.0.1:18081.
+# return 200 here is dummy-equivalent: ModSecurity already ran on the public
+# server. Do not put return on location / of :8080 (that skips CRS phases).
+# max_ranges 0 so a tiny 200 is not 416.
+
+server {
+    listen 127.0.0.1:18081;
+    server_name _;
+    max_ranges 0;
+    location / {
+        default_type text/plain;
+        return 200 "OK";
+    }
+}

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
@@ -1,43 +1,43 @@
-Developer review: in progress — 2026-09-03T03:51:24Z
+Developer review: in progress — 2026-09-03T04:00:43Z
 
 ## What this changes
 **Operators.** None.
 
 **Admin users.** None.
 
-**Developers.** None.
+**Developers.** CRS Docker BACKEND overlay notes landed under `knowledge/research/ext_modsecurity_crs-docker_backend/` (inspect-only vs `proxy_pass` / `ProxyPass`). No compose overlay yet.
 
 **End users.** None.
 
 ## Motivation
-On main, every CRS inspect still `ProxyPass` / `proxy_pass` to an unlabeled dummy whoami. That hop is not the real app, so a large body or a `Range` header can become a sidecar 4xx that this plugin copies as a security block, and operators confuse dummy with Traefik’s backend. Without this PR those false blocks and the extra hop stay.
+On main, every CRS inspect still `ProxyPass` / `proxy_pass` to an unlabeled dummy whoami. That hop is not the real app, so a `Range` header or a small origin body can become a sidecar 416 that this plugin copies as a security block, and operators confuse dummy with Traefik’s backend. Without this PR those false blocks and the extra hop stay.
 
 ## Merge readiness
-Prepare is grounded (`qualified-with-gaps`); the overlay is not implemented. 3 items remain.
+Explore reproduced the dummy hop and measured before-change throughput; the overlay is not implemented. 3 items remain.
 
 Priority: P2 — real operator pain from dummy/whoami (false 4xx blocks, extra hop), with a workaround of keeping dummy
-Reviewed head: 066ca7c
-Owner decision: None.
+Reviewed head: 097fe53
+Owner decision: Required. See Decision needed.
 
 ## Review scores
 | Measure | Result | What it means |
 | --- | --- | --- |
-| Overall readiness | 3/6 | CI still running; product overlay not started |
-| CI proof | 3/6 | Integration Tests in progress; lint/build succeeded |
+| Overall readiness | 6/6 | CI green; product overlay still not in the diff |
+| CI proof | 6/6 | All six checks succeeded |
 | Local tests proof | N/A | Before implement (`localTests: none`) |
 | Review resolution | 6/6 | OPEN PR 31, no review comments |
 
 ## Verification
 | Check | Result | Evidence |
 | --- | --- | --- |
-| Branch | 2026-09-03-remove-2nd-hop pushed | `git`; origin/2026-09-03-remove-2nd-hop |
-| OpenSpec | none | `openspec/changes/` |
+| Branch | 2026-09-03-remove-2nd-hop pushed | `git` |
+| OpenSpec | none | `openspec list --json` empty changes |
 | Pull request | https://github.com/david-garcia-garcia/traefik-modsecurity/pull/31 | GitHub list |
-| CI | Integration Tests (apache) in progress https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807613/job/100515693751 ; Integration Tests (nginx) in progress https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807613/job/100515693774 ; Test Runner Script Validation success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807613/job/100515693686 ; lint success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807609/job/100515693669 ; build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807632/job/100515693600 ; Build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807601/job/100515693506 | pull_request_read get_check_runs |
+| CI | Integration Tests (apache) success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007773/job/100516282906 ; Integration Tests (nginx) success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007773/job/100516282957 ; Test Runner Script Validation success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007773/job/100516282614 ; lint success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007828/job/100516282863 ; build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007780/job/100516282702 ; Build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007978/job/100516283238 | pull_request_read get_check_runs |
 | Local tests | none | handoff.yaml localTests |
-| PR comments | no comments | pull_request_read get_comments / get_review_comments |
+| PR comments | no comments | prepare inventory; no new comments this phase |
 | Security | None. | no apply; no `codereview.md` |
-| Performance | not seen — before/after allow-path throughput not measured | caller asked for numbers on this card; prepare did not bench |
+| Performance | before: GET 5077 req/s (9.84 ms avg), POST 1098 req/s (45.47 ms avg); after not seen | bombardier -c 50 -d 15s, Apache `docker-compose.test.yml`, `http://localhost:8000/protected` |
 
 ## Specs
 None.
@@ -46,14 +46,16 @@ None.
 - [ ] [note] [large] README `BenchmarkProtectedEndpoint` → no `Benchmark*` in this tree — README documents an integration bench that is not found. Not this ticket.
 
 ## How this fits together
-Local inspect-only sidecar spec is grounded on branch 2026-09-03-remove-2nd-hop as PR 31 against main. Next phase is explore (including the nginx `return` vs CRS phase-2 question and a before-change throughput measurement).
+Local inspect-only sidecar spec is explored on branch 2026-09-03-remove-2nd-hop as PR 31 against main. Nginx `return 200` is rejected; Apache `/healthz` rewrite is the Apache path; after throughput still required.
 
 ## Decision needed
-None.
+| Question | Decision | By |
+| --- | --- | --- |
+| Exact nginx drain listen port and entrypoint script name? | assumed — `127.0.0.1:18081`, script under `crs-nginx/` mounted into `/docker-entrypoint.d/`. Implement may pick a free high port if 18081 collides; keep loopback-only. | explore |
 
 ## Before merge
-- [ ] Overlay CRS so the sidecar answers HTTP 200 after request phases; delete unlabeled `dummy`
-- [ ] Measure allow-path throughput before the overlay and after; put before, after, and delta on this card
+- [ ] Overlay CRS so the sidecar answers HTTP 200 after request phases; delete unlabeled `dummy` (nginx: drain-200, not `return`)
+- [ ] Measure allow-path throughput after the overlay; put before (GET 5077 req/s, POST 1098 req/s), after, and delta on this card
 - [ ] Prove live CRS gates: GET+POST allow, URI block, POST-body block, Range not sidecar 416, client-IP audit, no dummy service
 
 ## Findings
@@ -65,32 +67,34 @@ None.
 None.
 
 ### Performance
-Before/after allow-path throughput is not measured. Implement must bench on the live stack and put the numbers here. Do not add a `Benchmark*` suite unless that is the only way to get them.
+Before-change Apache allow-path (bombardier -c 50 -d 15s, `/protected`): GET 5077.24 req/s avg, 9.84 ms latency, 76072 2xx / 125 5xx; POST 1098.11 req/s avg, 45.47 ms latency, 12600 2xx / 3901 5xx. After not measured. Nginx `return 200` skips CRS (including URI probes) — do not ship it.
 
 ### Review metrics
 | Metric | Value | Why it matters |
 | --- | --- | --- |
-| Specs in this PR | none | Same list as Specs; no product spec yet |
+| Specs in this PR | none | Same list as Specs |
 | Open reviewer comments walked | 0 FIX / 0 ANSWER / 0 open | Unanswered review is merge risk |
-| Reviewed head | 066ca7cfce5d7acc7c889f3036256e923a94fdba | Card must match the branch you measured |
+| Reviewed head | 097fe536ee2548c05c1172f545d9c7ebce29b1cb | Card must match the branch you measured |
 
 ### Stored data model
 None.
 
 ### Technical review
-Best possible solution: not implemented. DestBranch still proxies CRS to dummy whoami.
+Best possible solution: not implemented. DestBranch still proxies CRS to dummy whoami. Explore says Apache `/healthz` rewrite for inspect-only; nginx drain-200 on loopback.
 
-Do we have a high-confidence way to reproduce? Yes — compose `dummy` + `BACKEND=http://dummy` and `crs-apache/httpd-vhosts.conf` `ProxyPass`.
+Do we have a high-confidence way to reproduce? Yes — dummy running; Traefik `Range: bytes=10240-` → 416; WAF-direct GET body is dummy hostname `aa247ec7bea4` vs app `1d6f75bc6da6`; nginx return spike allowed SQLi with 200.
 
-Is this the best way to solve the issue? Not decided in prepare. Explore must confirm nginx `return 200` still runs CRS request-body inspection before we lock that overlay.
+Is this the best way to solve the issue? Apache rewrite-200 matches the image’s own `/healthz` and still 403s body SQLi. Nginx `return` is not; drain-200 is the fallback the brief already named.
 
 ### Evidence
 What I checked:
-- Local spec dumped from `modsecissues/inspect-only-sidecar.md` plus caller extras (worktree, before/after throughput on this card)
-- `qualify: qualified-with-gaps` (`requirement.md`; CRS overlay phase-2 and throughput still unknown)
-- Worktree `D:/repositories/traefik-modsecurity-plugin-2026-09-03-remove-2nd-hop` from `origin/main` at `2f39486`
-- Stub PR 31 opened; CI Integration Tests still in progress
-- No OPEN PR comments
+- `docker compose -f docker-compose.test.yml` up; dummy running
+- GET `/protected` 200 (app whoami); URI SQLi 403; POST allow 200; POST body SQLi 403
+- `Range: bytes=10240-` via Traefik and at `waf:8080/` → 416; Apache `/healthz` + Range also 416
+- WAF-direct GET body is dummy whoami, not the app
+- nginx throwaway `return 200` overlay: URI SQLi, traversal, POST SQLi all 200
+- bombardier before numbers above
+- CI all success on 097fe53
 
 ### Rank-up moves
 None.

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
@@ -1,43 +1,43 @@
-Developer review: in progress — 2026-09-03T04:05:06Z
+Developer review: in progress — 2026-09-03T04:40:10Z
 
 ## What this changes
-**Operators.** None yet (overlay not applied). Compose still has dummy on main.
+**Operators.** Demo compose (`docker-compose.yml` / `docker-compose.local.yml`) mounts `crs-apache/httpd-vhosts.drain.conf` and no longer runs unlabeled `dummy`. CRS inspects a copy and answers 200; Traefik `next` is the app.
 
 **Admin users.** None.
 
-**Developers.** OpenSpec change `inspect-only-crs-sidecar` adds spec `core_crs_sidecar_inspect-only` (inspect-only CRS sidecar, no dummy origin). Plugin `ServeHTTP` is unchanged.
+**Developers.** Four named test stacks remain: `apache-whoami`, `nginx-whoami`, `apache-drain`, `nginx-drain`. `./Test-Integration.ps1 -Stack` / `-AllStacks` and CI matrix cover all four. Pester prints `BENCH stack=` bombardier lines. Plugin `ServeHTTP` is unchanged.
 
-**End users.** None.
+**End users.** On drain/demo, `Range: bytes=10240-` is no longer copied as a sidecar 416 WAF block. Whoami test stacks still can 416 (dummy origin).
 
 ## Motivation
-On main, every CRS inspect still `ProxyPass` / `proxy_pass` to an unlabeled dummy whoami. That hop is not the real app, so a `Range` header or a small origin body can become a sidecar 416 that this plugin copies as a security block, and operators confuse dummy with Traefik’s backend. Without this PR those false blocks and the extra hop stay.
+On main, every CRS inspect still `ProxyPass` / `proxy_pass` to unlabeled dummy whoami. That hop is not the real app, so dummy/whoami behavior (Range 416) is copied as a security block, operators confuse dummy with Traefik's backend, and every allow pays an extra origin round-trip. That extra hop is one slice of the long-standing WAF-path cost tracked upstream in [acouvreur/traefik-modsecurity-plugin#2](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2) (bombardier: no-WAF ~14430 req/s vs WAF ~748 req/s, ~20x). Without this PR those false blocks stay, and we cannot compare dummy vs inspect-only on the same suite.
 
 ## Merge readiness
-Propose is apply-ready; overlay not implemented. 3 items remain.
+Implement landed four stacks + benches; CI on this head not seen yet. 2 items remain.
 
-Priority: P2 — real operator pain from dummy/whoami (false 4xx blocks, extra hop), with a workaround of keeping dummy
-Reviewed head: c7f089c
-Owner decision: Required. See Decision needed.
+Priority: P2 — real operator pain from dummy/whoami (false 4xx blocks, extra hop), with a workaround of keeping dummy on whoami test stacks
+Reviewed head: 8c32789
+Owner decision: None.
 
 ## Review scores
 | Measure | Result | What it means |
 | --- | --- | --- |
-| Overall readiness | 3/6 | Apache integration tests still running on the explore commit |
-| CI proof | 3/6 | Integration Tests (apache) in progress; nginx/lint/build succeeded |
-| Local tests proof | N/A | Before implement (`localTests: none`) |
+| Overall readiness | 1/6 | Pushed apply; CI on this head not seen |
+| CI proof | 1/6 | not seen on 8c32789 |
+| Local tests proof | N/A | prHost github — CI proof covers remote |
 | Review resolution | 6/6 | OPEN PR 31, no review comments |
 
 ## Verification
 | Check | Result | Evidence |
 | --- | --- | --- |
-| Branch | 2026-09-03-remove-2nd-hop pushed | `git` |
-| OpenSpec | inspect-only-crs-sidecar | `openspec/changes/inspect-only-crs-sidecar/` 4/4 artifacts |
+| Branch | 2026-09-03-remove-2nd-hop pushed | `git` (push follows this card write) |
+| OpenSpec | inspect-only-crs-sidecar | `openspec/changes/inspect-only-crs-sidecar/` |
 | Pull request | https://github.com/david-garcia-garcia/traefik-modsecurity/pull/31 | GitHub |
-| CI | Integration Tests (apache) in progress https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575790/job/100517970039 ; Integration Tests (nginx) success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575790/job/100517970082 ; Test Runner Script Validation success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575790/job/100517969861 ; lint success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575752/job/100517969655 ; build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575846/job/100517969970 ; Build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575778/job/100517969923 | pull_request_read get_check_runs |
-| Local tests | none | handoff.yaml |
+| CI | not seen | not measured on this head yet |
+| Local tests | passed | `./Test-Integration.ps1 -AllStacks -TestPath ./scripts/integration-tests.Tests.ps1` — all four stacks 0 failed (whoami 45 pass / 2 skip; drain 46 pass / 1 skip). Runner exit-code leak fixed; apache-drain bench-only re-run exit 0 |
 | PR comments | no comments | no comments.md items |
-| Security | None. | no apply; no `codereview.md` |
-| Performance | before: GET 5077 req/s (9.84 ms avg), POST 1098 req/s (45.47 ms avg); after not seen | bombardier -c 50 -d 15s, Apache test compose, `/protected` |
+| Security | None. | no `codereview.md` yet |
+| Performance | See Agent review details — pinned to [acouvreur#2](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2) | bombardier `-c 50 -d 15s` `/protected` |
 
 ## Specs
 - [core_crs_sidecar_inspect-only](https://github.com/david-garcia-garcia/traefik-modsecurity/blob/2026-09-03-remove-2nd-hop/openspec/changes/inspect-only-crs-sidecar/proposal.md) — added
@@ -46,17 +46,16 @@ Owner decision: Required. See Decision needed.
 - [ ] [note] [large] README `BenchmarkProtectedEndpoint` → no `Benchmark*` in this tree — README documents an integration bench that is not found. Not this ticket.
 
 ## How this fits together
-Inspect-only CRS sidecar is specified on branch 2026-09-03-remove-2nd-hop as PR 31. Implement applies Apache rewrite-200 and nginx drain-200, then re-benches.
+Inspect-only CRS overlay is on branch `2026-09-03-remove-2nd-hop` as PR 31. Demo is drain-only; tests keep whoami + drain and bench all four. Throughput is the same class of measurement as [acouvreur#2](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2) (bombardier on WAF vs non-WAF). This PR does not remove the WAF hop; it removes the dummy origin after CRS.
 
 ## Decision needed
-| Question | Decision | By |
-| --- | --- | --- |
-| Exact nginx drain listen port and entrypoint script name? | assumed — `127.0.0.1:18081`, script under `crs-nginx/` mounted into `/docker-entrypoint.d/`. Implement may pick a free high port if 18081 collides; keep loopback-only. | explore |
+None.
 
 ## Before merge
-- [ ] Overlay CRS inspect-only 200; delete unlabeled `dummy` (nginx: drain-200, not `return`)
-- [ ] Measure after throughput; put before (GET 5077 req/s, POST 1098 req/s), after, and delta on this card
-- [ ] Prove live CRS gates: GET+POST allow, URI block, POST-body block, Range not sidecar 416, client-IP audit, no dummy
+- [ ] [P3] Wait for CI on the four-stack matrix (bombardier installed in the workflow)
+- [x] Keep apache+whoami, nginx+whoami, apache+drain, nginx+drain in the suite and bench all four
+- [x] Overlay CRS inspect-only 200 on demo + drain stacks (nginx: loopback origin, not `return` on CRS `location /`)
+- [x] Prove live CRS gates: GET+POST allow, URI block, POST-body block, Range not sidecar 416 on drain, dummy present only on whoami stacks
 
 ## Findings
 None.
@@ -67,31 +66,45 @@ None.
 None.
 
 ### Performance
-Before-change Apache allow-path: GET 5077.24 req/s / 9.84 ms (76072 2xx, 125 5xx); POST 1098.11 req/s / 45.47 ms (12600 2xx, 3901 5xx). After not measured. Nginx `return 200` skipped CRS — design forbids it.
+Upstream pin: [Increase plugin performance (#2)](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2) — bombardier, WAF path ~20x slower than no-WAF (748 vs 14430 req/s at `-c 125 -d 10s`). This ticket measures the **dummy origin hop inside the WAF path**, not WAF-off.
+
+Before (explore, Apache whoami, `-c 50 -d 15s` `/protected`): GET 5077 req/s / 9.84 ms (76072 2xx / 125 5xx); POST 1098 req/s / 45.47 ms (12600 2xx / 3901 5xx).
+
+After (same flags, this apply):
+
+| Stack | GET req/s | GET latency | GET 2xx/5xx | POST req/s | POST latency | POST 2xx/5xx |
+| --- | --- | --- | --- | --- | --- | --- |
+| apache-whoami | 4999.25 | 10.00 ms | 74956 / 67 | 1149.90 | 43.44 ms | 12299 / 4995 |
+| nginx-whoami | 3989.81 | 12.52 ms | 59894 / 0 | 1947.69 | 25.66 ms | 27451 / 1802 |
+| apache-drain | 5211.54 | 9.60 ms | 78061 / 145 | 1348.95 | 37.02 ms | 17554 / 2727 |
+| nginx-drain | 3588.45 | 13.93 ms | 53862 / 0 | 2552.73 | 19.57 ms | 38341 / 0 |
+
+Apache drain vs explore whoami: GET ~+3% (noise), POST ~+23%. Nginx drain vs nginx whoami (same session): GET −10%, POST +31% and 0 5xx. CRS still dominates; dummy hop is not the 20x in #2.
 
 ### Review metrics
 | Metric | Value | Why it matters |
 | --- | --- | --- |
 | Specs in this PR | 1 added / 0 modified | Same list as Specs |
 | Open reviewer comments walked | 0 FIX / 0 ANSWER / 0 open | Unanswered review is merge risk |
-| Reviewed head | c7f089c (working tree also has apply-ready OpenSpec) | Card must match the branch you measured |
+| Reviewed head | 8c327894b233cd05818ec582949767fd818ef890 | Card must match the branch you measured |
 
 ### Stored data model
 None.
 
 ### Technical review
-Best possible solution vs main: not implemented. Spec + design: Apache `/healthz` rewrite; nginx loopback drain-200; unset Range.
+Best possible solution vs main: inspect-only overlay for demo/drain; keep whoami stacks so #2-style bombardier can compare origins. Nginx drain is a loopback `server` after `proxy_pass` (`max_ranges 0`), not `return` on CRS `location /` (measured skip) and not serial `nc`.
 
-Do we have a high-confidence way to reproduce? Yes — explore measured dummy hop, 416, and nginx return skipping CRS.
+Do we have a high-confidence way to reproduce? Yes — Pester `Allow-path throughput` plus `./Test-Integration.ps1 -AllStacks`.
 
-Is this the best way to solve the issue? Yes vs DestBranch: inspect-only overlay, no plugin change, no dummy.
+Is this the best way to solve the issue? Yes vs DestBranch: overlay only, no plugin change, four-stack compare kept.
 
 ### Evidence
 What I checked:
-- `openspec validate --changes --strict` passed for `inspect-only-crs-sidecar`
-- FindSpecHost new `core_crs_sidecar_inspect-only` (not fold into plugin sidecar-request)
-- Explore before-change bombardier numbers
-- CI apache still in progress on explore commit
+- nginx-drain and apache-drain smoke: GET 200, Range 200, URI 403, POST 200, POST SQLi 403, no dummy
+- `./Test-Integration.ps1 -AllStacks` main Pester file: 0 failed on all four
+- BENCH lines above (bombardier `-c 50 -d 15s`)
+- Upstream [acouvreur#2](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2) cited as the performance issue this measurement family belongs to
 
 ### Rank-up moves
-None.
+- Absolute GET RPS on nginx-drain was slightly below nginx-whoami; treat as noise unless a second run repeats it.
+

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
@@ -1,11 +1,96 @@
-Developer agent: started — 2026-09-03T03:47:03Z
+Developer review: in progress — 2026-09-03T03:51:24Z
 
-IssueKey: 2026-09-03-remove-2nd-hop
-JobName: 2026-09-03-remove-2nd-hop
-Dumping ticket next.
+## What this changes
+**Operators.** None.
 
-Delivery status
-- Branch: 2026-09-03-remove-2nd-hop (unknown)
-- OpenSpec: none
-- Pull request: none
-- CI: not seen
+**Admin users.** None.
+
+**Developers.** None.
+
+**End users.** None.
+
+## Motivation
+On main, every CRS inspect still `ProxyPass` / `proxy_pass` to an unlabeled dummy whoami. That hop is not the real app, so a large body or a `Range` header can become a sidecar 4xx that this plugin copies as a security block, and operators confuse dummy with Traefik’s backend. Without this PR those false blocks and the extra hop stay.
+
+## Merge readiness
+Prepare is grounded (`qualified-with-gaps`); the overlay is not implemented. 3 items remain.
+
+Priority: P2 — real operator pain from dummy/whoami (false 4xx blocks, extra hop), with a workaround of keeping dummy
+Reviewed head: 066ca7c
+Owner decision: None.
+
+## Review scores
+| Measure | Result | What it means |
+| --- | --- | --- |
+| Overall readiness | 3/6 | CI still running; product overlay not started |
+| CI proof | 3/6 | Integration Tests in progress; lint/build succeeded |
+| Local tests proof | N/A | Before implement (`localTests: none`) |
+| Review resolution | 6/6 | OPEN PR 31, no review comments |
+
+## Verification
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Branch | 2026-09-03-remove-2nd-hop pushed | `git`; origin/2026-09-03-remove-2nd-hop |
+| OpenSpec | none | `openspec/changes/` |
+| Pull request | https://github.com/david-garcia-garcia/traefik-modsecurity/pull/31 | GitHub list |
+| CI | Integration Tests (apache) in progress https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807613/job/100515693751 ; Integration Tests (nginx) in progress https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807613/job/100515693774 ; Test Runner Script Validation success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807613/job/100515693686 ; lint success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807609/job/100515693669 ; build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807632/job/100515693600 ; Build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33712807601/job/100515693506 | pull_request_read get_check_runs |
+| Local tests | none | handoff.yaml localTests |
+| PR comments | no comments | pull_request_read get_comments / get_review_comments |
+| Security | None. | no apply; no `codereview.md` |
+| Performance | not seen — before/after allow-path throughput not measured | caller asked for numbers on this card; prepare did not bench |
+
+## Specs
+None.
+
+## Follow-up issues
+- [ ] [note] [large] README `BenchmarkProtectedEndpoint` → no `Benchmark*` in this tree — README documents an integration bench that is not found. Not this ticket.
+
+## How this fits together
+Local inspect-only sidecar spec is grounded on branch 2026-09-03-remove-2nd-hop as PR 31 against main. Next phase is explore (including the nginx `return` vs CRS phase-2 question and a before-change throughput measurement).
+
+## Decision needed
+None.
+
+## Before merge
+- [ ] Overlay CRS so the sidecar answers HTTP 200 after request phases; delete unlabeled `dummy`
+- [ ] Measure allow-path throughput before the overlay and after; put before, after, and delta on this card
+- [ ] Prove live CRS gates: GET+POST allow, URI block, POST-body block, Range not sidecar 416, client-IP audit, no dummy service
+
+## Findings
+None.
+
+## Agent review details
+
+### Security
+None.
+
+### Performance
+Before/after allow-path throughput is not measured. Implement must bench on the live stack and put the numbers here. Do not add a `Benchmark*` suite unless that is the only way to get them.
+
+### Review metrics
+| Metric | Value | Why it matters |
+| --- | --- | --- |
+| Specs in this PR | none | Same list as Specs; no product spec yet |
+| Open reviewer comments walked | 0 FIX / 0 ANSWER / 0 open | Unanswered review is merge risk |
+| Reviewed head | 066ca7cfce5d7acc7c889f3036256e923a94fdba | Card must match the branch you measured |
+
+### Stored data model
+None.
+
+### Technical review
+Best possible solution: not implemented. DestBranch still proxies CRS to dummy whoami.
+
+Do we have a high-confidence way to reproduce? Yes — compose `dummy` + `BACKEND=http://dummy` and `crs-apache/httpd-vhosts.conf` `ProxyPass`.
+
+Is this the best way to solve the issue? Not decided in prepare. Explore must confirm nginx `return 200` still runs CRS request-body inspection before we lock that overlay.
+
+### Evidence
+What I checked:
+- Local spec dumped from `modsecissues/inspect-only-sidecar.md` plus caller extras (worktree, before/after throughput on this card)
+- `qualify: qualified-with-gaps` (`requirement.md`; CRS overlay phase-2 and throughput still unknown)
+- Worktree `D:/repositories/traefik-modsecurity-plugin-2026-09-03-remove-2nd-hop` from `origin/main` at `2f39486`
+- Stub PR 31 opened; CI Integration Tests still in progress
+- No OPEN PR comments
+
+### Rank-up moves
+None.

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
@@ -16,14 +16,14 @@ On main, every CRS inspect still `ProxyPass` / `proxy_pass` to unlabeled dummy w
 Implement landed four stacks + benches; CI on this head not seen yet. 2 items remain.
 
 Priority: P2 — real operator pain from dummy/whoami (false 4xx blocks, extra hop), with a workaround of keeping dummy on whoami test stacks
-Reviewed head: 8c32789
+Reviewed head: 13c19a0
 Owner decision: None.
 
 ## Review scores
 | Measure | Result | What it means |
 | --- | --- | --- |
 | Overall readiness | 1/6 | Pushed apply; CI on this head not seen |
-| CI proof | 1/6 | not seen on 8c32789 |
+| CI proof | 1/6 | not seen on 13c19a0 |
 | Local tests proof | N/A | prHost github — CI proof covers remote |
 | Review resolution | 6/6 | OPEN PR 31, no review comments |
 
@@ -86,7 +86,7 @@ Apache drain vs explore whoami: GET ~+3% (noise), POST ~+23%. Nginx drain vs ngi
 | --- | --- | --- |
 | Specs in this PR | 1 added / 0 modified | Same list as Specs |
 | Open reviewer comments walked | 0 FIX / 0 ANSWER / 0 open | Unanswered review is merge risk |
-| Reviewed head | 8c327894b233cd05818ec582949767fd818ef890 | Card must match the branch you measured |
+| Reviewed head | 13c19a054bb9bcf11de533d8c8d0d3653b192258 | Card must match the branch you measured |
 
 ### Stored data model
 None.
@@ -107,4 +107,5 @@ What I checked:
 
 ### Rank-up moves
 - Absolute GET RPS on nginx-drain was slightly below nginx-whoami; treat as noise unless a second run repeats it.
+
 

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
@@ -1,11 +1,11 @@
-Developer review: in progress — 2026-09-03T04:00:43Z
+Developer review: in progress — 2026-09-03T04:05:06Z
 
 ## What this changes
-**Operators.** None.
+**Operators.** None yet (overlay not applied). Compose still has dummy on main.
 
 **Admin users.** None.
 
-**Developers.** CRS Docker BACKEND overlay notes landed under `knowledge/research/ext_modsecurity_crs-docker_backend/` (inspect-only vs `proxy_pass` / `ProxyPass`). No compose overlay yet.
+**Developers.** OpenSpec change `inspect-only-crs-sidecar` adds spec `core_crs_sidecar_inspect-only` (inspect-only CRS sidecar, no dummy origin). Plugin `ServeHTTP` is unchanged.
 
 **End users.** None.
 
@@ -13,17 +13,17 @@ Developer review: in progress — 2026-09-03T04:00:43Z
 On main, every CRS inspect still `ProxyPass` / `proxy_pass` to an unlabeled dummy whoami. That hop is not the real app, so a `Range` header or a small origin body can become a sidecar 416 that this plugin copies as a security block, and operators confuse dummy with Traefik’s backend. Without this PR those false blocks and the extra hop stay.
 
 ## Merge readiness
-Explore reproduced the dummy hop and measured before-change throughput; the overlay is not implemented. 3 items remain.
+Propose is apply-ready; overlay not implemented. 3 items remain.
 
 Priority: P2 — real operator pain from dummy/whoami (false 4xx blocks, extra hop), with a workaround of keeping dummy
-Reviewed head: 097fe53
+Reviewed head: c7f089c
 Owner decision: Required. See Decision needed.
 
 ## Review scores
 | Measure | Result | What it means |
 | --- | --- | --- |
-| Overall readiness | 6/6 | CI green; product overlay still not in the diff |
-| CI proof | 6/6 | All six checks succeeded |
+| Overall readiness | 3/6 | Apache integration tests still running on the explore commit |
+| CI proof | 3/6 | Integration Tests (apache) in progress; nginx/lint/build succeeded |
 | Local tests proof | N/A | Before implement (`localTests: none`) |
 | Review resolution | 6/6 | OPEN PR 31, no review comments |
 
@@ -31,22 +31,22 @@ Owner decision: Required. See Decision needed.
 | Check | Result | Evidence |
 | --- | --- | --- |
 | Branch | 2026-09-03-remove-2nd-hop pushed | `git` |
-| OpenSpec | none | `openspec list --json` empty changes |
-| Pull request | https://github.com/david-garcia-garcia/traefik-modsecurity/pull/31 | GitHub list |
-| CI | Integration Tests (apache) success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007773/job/100516282906 ; Integration Tests (nginx) success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007773/job/100516282957 ; Test Runner Script Validation success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007773/job/100516282614 ; lint success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007828/job/100516282863 ; build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007780/job/100516282702 ; Build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713007978/job/100516283238 | pull_request_read get_check_runs |
-| Local tests | none | handoff.yaml localTests |
-| PR comments | no comments | prepare inventory; no new comments this phase |
+| OpenSpec | inspect-only-crs-sidecar | `openspec/changes/inspect-only-crs-sidecar/` 4/4 artifacts |
+| Pull request | https://github.com/david-garcia-garcia/traefik-modsecurity/pull/31 | GitHub |
+| CI | Integration Tests (apache) in progress https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575790/job/100517970039 ; Integration Tests (nginx) success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575790/job/100517970082 ; Test Runner Script Validation success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575790/job/100517969861 ; lint success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575752/job/100517969655 ; build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575846/job/100517969970 ; Build success https://github.com/david-garcia-garcia/traefik-modsecurity/actions/runs/33713575778/job/100517969923 | pull_request_read get_check_runs |
+| Local tests | none | handoff.yaml |
+| PR comments | no comments | no comments.md items |
 | Security | None. | no apply; no `codereview.md` |
-| Performance | before: GET 5077 req/s (9.84 ms avg), POST 1098 req/s (45.47 ms avg); after not seen | bombardier -c 50 -d 15s, Apache `docker-compose.test.yml`, `http://localhost:8000/protected` |
+| Performance | before: GET 5077 req/s (9.84 ms avg), POST 1098 req/s (45.47 ms avg); after not seen | bombardier -c 50 -d 15s, Apache test compose, `/protected` |
 
 ## Specs
-None.
+- [core_crs_sidecar_inspect-only](https://github.com/david-garcia-garcia/traefik-modsecurity/blob/2026-09-03-remove-2nd-hop/openspec/changes/inspect-only-crs-sidecar/proposal.md) — added
 
 ## Follow-up issues
 - [ ] [note] [large] README `BenchmarkProtectedEndpoint` → no `Benchmark*` in this tree — README documents an integration bench that is not found. Not this ticket.
 
 ## How this fits together
-Local inspect-only sidecar spec is explored on branch 2026-09-03-remove-2nd-hop as PR 31 against main. Nginx `return 200` is rejected; Apache `/healthz` rewrite is the Apache path; after throughput still required.
+Inspect-only CRS sidecar is specified on branch 2026-09-03-remove-2nd-hop as PR 31. Implement applies Apache rewrite-200 and nginx drain-200, then re-benches.
 
 ## Decision needed
 | Question | Decision | By |
@@ -54,9 +54,9 @@ Local inspect-only sidecar spec is explored on branch 2026-09-03-remove-2nd-hop 
 | Exact nginx drain listen port and entrypoint script name? | assumed — `127.0.0.1:18081`, script under `crs-nginx/` mounted into `/docker-entrypoint.d/`. Implement may pick a free high port if 18081 collides; keep loopback-only. | explore |
 
 ## Before merge
-- [ ] Overlay CRS so the sidecar answers HTTP 200 after request phases; delete unlabeled `dummy` (nginx: drain-200, not `return`)
-- [ ] Measure allow-path throughput after the overlay; put before (GET 5077 req/s, POST 1098 req/s), after, and delta on this card
-- [ ] Prove live CRS gates: GET+POST allow, URI block, POST-body block, Range not sidecar 416, client-IP audit, no dummy service
+- [ ] Overlay CRS inspect-only 200; delete unlabeled `dummy` (nginx: drain-200, not `return`)
+- [ ] Measure after throughput; put before (GET 5077 req/s, POST 1098 req/s), after, and delta on this card
+- [ ] Prove live CRS gates: GET+POST allow, URI block, POST-body block, Range not sidecar 416, client-IP audit, no dummy
 
 ## Findings
 None.
@@ -67,34 +67,31 @@ None.
 None.
 
 ### Performance
-Before-change Apache allow-path (bombardier -c 50 -d 15s, `/protected`): GET 5077.24 req/s avg, 9.84 ms latency, 76072 2xx / 125 5xx; POST 1098.11 req/s avg, 45.47 ms latency, 12600 2xx / 3901 5xx. After not measured. Nginx `return 200` skips CRS (including URI probes) — do not ship it.
+Before-change Apache allow-path: GET 5077.24 req/s / 9.84 ms (76072 2xx, 125 5xx); POST 1098.11 req/s / 45.47 ms (12600 2xx, 3901 5xx). After not measured. Nginx `return 200` skipped CRS — design forbids it.
 
 ### Review metrics
 | Metric | Value | Why it matters |
 | --- | --- | --- |
-| Specs in this PR | none | Same list as Specs |
+| Specs in this PR | 1 added / 0 modified | Same list as Specs |
 | Open reviewer comments walked | 0 FIX / 0 ANSWER / 0 open | Unanswered review is merge risk |
-| Reviewed head | 097fe536ee2548c05c1172f545d9c7ebce29b1cb | Card must match the branch you measured |
+| Reviewed head | c7f089c (working tree also has apply-ready OpenSpec) | Card must match the branch you measured |
 
 ### Stored data model
 None.
 
 ### Technical review
-Best possible solution: not implemented. DestBranch still proxies CRS to dummy whoami. Explore says Apache `/healthz` rewrite for inspect-only; nginx drain-200 on loopback.
+Best possible solution vs main: not implemented. Spec + design: Apache `/healthz` rewrite; nginx loopback drain-200; unset Range.
 
-Do we have a high-confidence way to reproduce? Yes — dummy running; Traefik `Range: bytes=10240-` → 416; WAF-direct GET body is dummy hostname `aa247ec7bea4` vs app `1d6f75bc6da6`; nginx return spike allowed SQLi with 200.
+Do we have a high-confidence way to reproduce? Yes — explore measured dummy hop, 416, and nginx return skipping CRS.
 
-Is this the best way to solve the issue? Apache rewrite-200 matches the image’s own `/healthz` and still 403s body SQLi. Nginx `return` is not; drain-200 is the fallback the brief already named.
+Is this the best way to solve the issue? Yes vs DestBranch: inspect-only overlay, no plugin change, no dummy.
 
 ### Evidence
 What I checked:
-- `docker compose -f docker-compose.test.yml` up; dummy running
-- GET `/protected` 200 (app whoami); URI SQLi 403; POST allow 200; POST body SQLi 403
-- `Range: bytes=10240-` via Traefik and at `waf:8080/` → 416; Apache `/healthz` + Range also 416
-- WAF-direct GET body is dummy whoami, not the app
-- nginx throwaway `return 200` overlay: URI SQLi, traversal, POST SQLi all 200
-- bombardier before numbers above
-- CI all success on 097fe53
+- `openspec validate --changes --strict` passed for `inspect-only-crs-sidecar`
+- FindSpecHost new `core_crs_sidecar_inspect-only` (not fold into plugin sidecar-request)
+- Explore before-change bombardier numbers
+- CI apache still in progress on explore commit
 
 ### Rank-up moves
 None.

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
@@ -16,14 +16,14 @@ On main, every CRS inspect still `ProxyPass` / `proxy_pass` to unlabeled dummy w
 Implement landed four stacks + benches; CI on this head not seen yet. 2 items remain.
 
 Priority: P2 — real operator pain from dummy/whoami (false 4xx blocks, extra hop), with a workaround of keeping dummy on whoami test stacks
-Reviewed head: 13c19a0
+Reviewed head: adb3e2ec373d3adb0484c87351b5bd7ad653a8bf
 Owner decision: None.
 
 ## Review scores
 | Measure | Result | What it means |
 | --- | --- | --- |
 | Overall readiness | 1/6 | Pushed apply; CI on this head not seen |
-| CI proof | 1/6 | not seen on 13c19a0 |
+| CI proof | 1/6 | not seen on adb3e2ec373d3adb0484c87351b5bd7ad653a8bf |
 | Local tests proof | N/A | prHost github — CI proof covers remote |
 | Review resolution | 6/6 | OPEN PR 31, no review comments |
 
@@ -86,7 +86,7 @@ Apache drain vs explore whoami: GET ~+3% (noise), POST ~+23%. Nginx drain vs ngi
 | --- | --- | --- |
 | Specs in this PR | 1 added / 0 modified | Same list as Specs |
 | Open reviewer comments walked | 0 FIX / 0 ANSWER / 0 open | Unanswered review is merge risk |
-| Reviewed head | 13c19a054bb9bcf11de533d8c8d0d3653b192258 | Card must match the branch you measured |
+| Reviewed head | adb3e2ec373d3adb0484c87351b5bd7ad653a8bf | Card must match the branch you measured |
 
 ### Stored data model
 None.
@@ -107,5 +107,6 @@ What I checked:
 
 ### Rank-up moves
 - Absolute GET RPS on nginx-drain was slightly below nginx-whoami; treat as noise unless a second run repeats it.
+
 
 

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/card.md
@@ -1,0 +1,11 @@
+Developer agent: started — 2026-09-03T03:47:03Z
+
+IssueKey: 2026-09-03-remove-2nd-hop
+JobName: 2026-09-03-remove-2nd-hop
+Dumping ticket next.
+
+Delivery status
+- Branch: 2026-09-03-remove-2nd-hop (unknown)
+- OpenSpec: none
+- Pull request: none
+- CI: not seen

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/explore.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/explore.md
@@ -1,0 +1,58 @@
+# Explore
+IssueKey: 2026-09-03-remove-2nd-hop
+
+## Concepts
+
+```
+Client → Traefik → plugin
+                     ├─ hop 1: HTTP copy → CRS :8080
+                     │              └─ hop 2 (today): ProxyPass/proxy_pass → dummy whoami
+                     └─ hop 3: next → labeled whoami / app
+```
+
+Hop 2 is the CRS image acting as a reverse proxy (`BACKEND`). Dummy’s body is not the app. The plugin treats sidecar `< 300` as allow and `3xx`/`4xx` as a security block (`pkg/modsecurity/serve.go`). A sidecar `416` from dummy (or from a tiny inspect-only body + `Range`) is copied to the client as a block.
+
+**Shadow WAF:** CRS inspects the copy and answers 200; Traefik `next` is the app.
+
+**Inspect-only 200:** sidecar HTTP 200 after ModSecurity **request** phases, no origin fetch.
+
+## Decisions
+
+- Do **not** change `pkg/modsecurity/serve.go`. Allow `< 300` and 3xx/4xx-as-block stay.
+- **Apache (pin 4.3.0-apache-alpine-202406090906):** drop `ProxyPass` / `ProxyPassReverse` / proxy knobs / websocket `[P]` to `${BACKEND_WS}` on `crs-apache/httpd-vhosts.conf`. Answer with the same pattern already used for `/healthz` in the image: `RewriteRule .* - [R=200,L]` + `ErrorDocument 200 "OK"`. Measured on live `/healthz`: GET allow 200, POST benign 200, URI SQLi 403, POST body `id=1 OR 1=1` 403. `rewrite_module` is loaded. `mod_lua` / `mod_cgi` exist on disk but are **not** loaded — do not add them.
+- **Apache Range:** `/healthz` + `Range: bytes=10240-` is still **416** (2-byte body, not dummy). Dummy whoami is also ~360 bytes, so today’s 416 is “origin too small,” not unique to whoami. Overlay must `RequestHeader unset Range` (and `If-Range`) so the sidecar stays 200. Plugin cannot ignore 416 (out of scope).
+- **Nginx `return 200`:** **abort.** Throwaway overlay of `proxy_backend.conf.template` → `return 200 'ok'` on pin `4.3.0-nginx-alpine-202406090906`: GET URI SQLi, path traversal, POST body SQLi, POST `UNION SELECT` were all **200**. CRS did not run (phase 1 and phase 2). Matches research inference (rewrite `return` before ModSecurity-nginx PREACCESS) and is worse than inferred: rewrite-phase rules also missed.
+- **Nginx inspect-only:** same-container **drain-200**. Image has `nc`, not `httpd`/`python`. Mount an entrypoint.d script that listens on loopback and always writes HTTP 200 (ignore Range); set `BACKEND=http://127.0.0.1:<port>`. Keep `crs-nginx/realip.conf`. Overlay `proxy_backend.conf.template` only if needed to drop `Range` toward that drain. No extra compose service. No `return`.
+- **Compose:** delete unlabeled `dummy` on `docker-compose.yml`, `docker-compose.local.yml`, `docker-compose.test.yml`, `docker-compose.test.nginx.yml`. Keep labeled whoami apps. Apache can drop `BACKEND=http://dummy`. Nginx sets `BACKEND` to the drain URL.
+- **Docs:** rewrite README dummy/always-200 as shadow WAF. Integration usage still names dummy until compose changes.
+- **Throughput before (this machine, Apache test compose, bombardier `-c 50 -d 15s`, `http://localhost:8000/protected`):**
+  - GET: **5077 req/s** avg, latency **9.84 ms** avg (max 133.65 ms). 76072 × 2xx, **125 × 5xx**. Throughput 2.71 MB/s.
+  - POST (`name=john&email=john@example.com`): **1098 req/s** avg, latency **45.47 ms** avg (max 198.37 ms). 12600 × 2xx, **3901 × 5xx**. Throughput 709.30 KB/s.
+  After numbers are implement. Same tool, same flags, same URL.
+- **Identity:** Traefik owns `X-Real-IP` / access-log `ClientHost`. CRS Apache `mod_remoteip` / nginx `real_ip` own audit `REMOTE_ADDR`. Keep existing overlays. Do not invent XFF in the plugin or in the inspect-only handler.
+
+## Open questions
+
+- Q: Does nginx `return 200` in `location /` still run CRS request-body inspection on pin 4.3.0-nginx?
+  Decision: resolved — no. Live spike: URI probes and POST body probes returned 200. Do not ship `return`. Use drain-200.
+  By: explore
+
+- Q: Which Apache method-agnostic 200 still runs request phases on pin 4.3.0-apache?
+  Decision: resolved — image `/healthz` `RewriteRule` `[R=200]` + `ErrorDocument 200`. URI and POST-body SQLi still 403; benign POST 200. Use that on `/`. Not Lua/CGI (modules not loaded).
+  By: explore
+
+- Q: Is today’s sidecar `416` only dummy/whoami?
+  Decision: resolved — also Apache `/healthz` 2-byte 200 + `Range: bytes=10240-` → 416. Unset `Range`/`If-Range` on the inspect-only vhost (nginx drain must ignore Range too).
+  By: explore
+
+- Q: Exact nginx drain listen port and entrypoint script name?
+  Decision: assumed — `127.0.0.1:18081`, script under `crs-nginx/` mounted into `/docker-entrypoint.d/`. Implement may pick a free high port if 18081 collides; keep loopback-only.
+  By: explore
+
+- Q: Who already owns client IP for WAF audit?
+  Decision: resolved — Traefik `X-Real-IP` / `ClientHost`; CRS `RemoteIPHeader` / nginx `real_ip`. Reuse those overlays. Do not reconstruct from `RemoteAddr`.
+  By: explore
+
+- Q: Before-change allow-path throughput?
+  Decision: resolved — GET 5077 req/s / 9.84 ms; POST 1098 req/s / 45.47 ms (bombardier -c 50 -d 15s, Apache `docker-compose.test.yml`, `/protected`). After still required on the delivery card.
+  By: explore

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/explore.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/explore.md
@@ -46,8 +46,12 @@ Hop 2 is the CRS image acting as a reverse proxy (`BACKEND`). Dummy’s body is 
   By: explore
 
 - Q: Exact nginx drain listen port and entrypoint script name?
-  Decision: assumed — `127.0.0.1:18081`, script under `crs-nginx/` mounted into `/docker-entrypoint.d/`. Implement may pick a free high port if 18081 collides; keep loopback-only.
-  By: explore
+  Decision: 127.0.0.1:18081 via crs-nginx/drain-origin.conf (second nginx server, max_ranges 0, return 200 after CRS proxy_pass). Not nc (serial) and not return on CRS location /.
+  By: implement
+
+- Q: Does the test suite drop dummy everywhere?
+  Decision: no. Keep apache+whoami, nginx+whoami, apache+drain, nginx+drain. Benchmark all four in Pester (bombardier). Demo compose is drain-only.
+  By: implement (human)
 
 - Q: Who already owns client IP for WAF audit?
   Decision: resolved — Traefik `X-Real-IP` / `ClientHost`; CRS `RemoteIPHeader` / nginx `real_ip`. Reuse those overlays. Do not reconstruct from `RemoteAddr`.

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/handoff.yaml
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/handoff.yaml
@@ -11,7 +11,7 @@ localTests: none
 requirement: requirement.md
 comments: none
 explore: explore.md
-change: none
+change: inspect-only-crs-sidecar
 pr:
   id: 31
   url: https://github.com/david-garcia-garcia/traefik-modsecurity/pull/31

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/handoff.yaml
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/handoff.yaml
@@ -12,4 +12,6 @@ requirement: requirement.md
 comments: none
 explore: none
 change: none
-pr: none
+pr:
+  id: 31
+  url: https://github.com/david-garcia-garcia/traefik-modsecurity/pull/31

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/handoff.yaml
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/handoff.yaml
@@ -1,0 +1,15 @@
+issueKey: 2026-09-03-remove-2nd-hop
+jobName: 2026-09-03-remove-2nd-hop
+issueHost: local
+issueRef: none
+prHost: github
+repoSlug: traefik-modsecurity
+destBranch: main
+qualify: qualified-with-gaps
+src: 2950614206b7af6ab47eb2114de9de475c88eda578261c780cff7c65ec0ed106
+localTests: none
+requirement: requirement.md
+comments: none
+explore: none
+change: none
+pr: none

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/handoff.yaml
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/handoff.yaml
@@ -7,7 +7,7 @@ repoSlug: traefik-modsecurity
 destBranch: main
 qualify: qualified-with-gaps
 src: 2950614206b7af6ab47eb2114de9de475c88eda578261c780cff7c65ec0ed106
-localTests: none
+localTests: passed
 requirement: requirement.md
 comments: none
 explore: explore.md

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/handoff.yaml
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/handoff.yaml
@@ -10,7 +10,7 @@ src: 2950614206b7af6ab47eb2114de9de475c88eda578261c780cff7c65ec0ed106
 localTests: none
 requirement: requirement.md
 comments: none
-explore: none
+explore: explore.md
 change: none
 pr:
   id: 31

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/issues.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/issues.md
@@ -1,0 +1,4 @@
+# Issues
+
+- [ ] note large  README `BenchmarkProtectedEndpoint` → no `Benchmark*` in this tree
+  Why: README documents an integration bench that is not found. Risk: operators copy a command that fails. Not this ticket.

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/knowledge.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/knowledge.md
@@ -1,0 +1,1 @@
+- created knowledge/research/ext_modsecurity_crs-docker_backend/

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
@@ -7,7 +7,7 @@ JobName: 2026-09-03-remove-2nd-hop
 | prepare | [x] | [x] | 2026-09-03T03:52:45Z |
 | explore | [x] | [x] | 2026-09-03T04:02:16Z |
 | propose | [x] | [x] | 2026-09-03T04:05:56Z |
-| implement | [ ] | [ ] | |
+| implement | [x] | [ ] | 2026-09-03T04:40:10Z |
 | codereview | [ ] | [ ] | |
 | devdocsimpact | [ ] | [ ] | |
 | archive | [ ] | [ ] | |

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
@@ -5,7 +5,7 @@ JobName: 2026-09-03-remove-2nd-hop
 | Phase | Work | Card | At |
 |-------|------|------|----|
 | prepare | [x] | [x] | 2026-09-03T03:52:45Z |
-| explore | [ ] | [ ] | |
+| explore | [x] | [x] | 2026-09-03T04:02:16Z |
 | propose | [ ] | [ ] | |
 | implement | [ ] | [ ] | |
 | codereview | [ ] | [ ] | |

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
@@ -6,7 +6,7 @@ JobName: 2026-09-03-remove-2nd-hop
 |-------|------|------|----|
 | prepare | [x] | [x] | 2026-09-03T03:52:45Z |
 | explore | [x] | [x] | 2026-09-03T04:02:16Z |
-| propose | [ ] | [ ] | |
+| propose | [x] | [x] | 2026-09-03T04:05:56Z |
 | implement | [ ] | [ ] | |
 | codereview | [ ] | [ ] | |
 | devdocsimpact | [ ] | [ ] | |

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
@@ -7,7 +7,7 @@ JobName: 2026-09-03-remove-2nd-hop
 | prepare | [x] | [x] | 2026-09-03T03:52:45Z |
 | explore | [x] | [x] | 2026-09-03T04:02:16Z |
 | propose | [x] | [x] | 2026-09-03T04:05:56Z |
-| implement | [x] | [ ] | 2026-09-03T04:40:10Z |
+| implement | [x] | [x] | 2026-09-03T04:40:10Z |
 | codereview | [ ] | [ ] | |
 | devdocsimpact | [ ] | [ ] | |
 | archive | [ ] | [ ] | |

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
@@ -4,7 +4,7 @@ JobName: 2026-09-03-remove-2nd-hop
 
 | Phase | Work | Card | At |
 |-------|------|------|----|
-| prepare | [ ] | [ ] | |
+| prepare | [x] | [x] | 2026-09-03T03:52:45Z |
 | explore | [ ] | [ ] | |
 | propose | [ ] | [ ] | |
 | implement | [ ] | [ ] | |

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/progress.md
@@ -1,0 +1,14 @@
+# Progress
+IssueKey: 2026-09-03-remove-2nd-hop
+JobName: 2026-09-03-remove-2nd-hop
+
+| Phase | Work | Card | At |
+|-------|------|------|----|
+| prepare | [ ] | [ ] | |
+| explore | [ ] | [ ] | |
+| propose | [ ] | [ ] | |
+| implement | [ ] | [ ] | |
+| codereview | [ ] | [ ] | |
+| devdocsimpact | [ ] | [ ] | |
+| archive | [ ] | [ ] | |
+| pullrequest | [ ] | [ ] | |

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/requirement.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/requirement.md
@@ -1,0 +1,61 @@
+# Requirement
+IssueKey: 2026-09-03-remove-2nd-hop
+
+## Problem
+
+The OWASP CRS sidecar still reverse-proxies every inspected request to an unlabeled `dummy` `traefik/whoami`. That second hop is not the real app (Traefik `next` is). It adds latency and turns dummy/whoami behavior into false WAF blocks (Apache body pass `AH01084`, `Range` → sidecar `416` copied as a security block). Operators also confuse dummy with the protected backend.
+
+## Current (code)
+
+- Apache overlay still proxies: `crs-apache/httpd-vhosts.conf` has `ProxyPass / ${BACKEND}/`, `ProxyPassReverse`, `ProxyErrorOverride`, `ProxyPreserveHost`, `ProxyTimeout`, and websocket `RewriteRule` `[P]` to `${BACKEND_WS}`. `RemoteIPHeader X-Real-IP` is already overlaid.
+- Compose wires dummy as that origin: `BACKEND=http://dummy` plus unlabeled `dummy: traefik/whoami` in `docker-compose.yml`, `docker-compose.local.yml`, `docker-compose.test.yml`, `docker-compose.test.nginx.yml`.
+- Nginx has no proxy overlay: `crs-nginx/realip.conf` only (`zz-realip.conf`). `docker-compose.test.nginx.yml` still sets `BACKEND=http://dummy`. Image `proxy_pass ${BACKEND}` is unchanged. Healthcheck probes `http://127.0.0.1:8080/` (not `/healthz`).
+- Plugin already treats sidecar status `< 300` as allow and calls `next`: `pkg/modsecurity/serve.go` (3xx/4xx copied as security block). No inspect-only Config knob exists.
+- README tells operators dummy exists so WAF “respond with 200 OK all the time”: `README.md` (“How it works”).
+- Integration usage still names dummy as the WAF origin: `knowledge/devdocs/build_testing_integration.md`. Sidecar-vs-next language already exists: `knowledge/devdocs/core_plugin_middleware.md`.
+- No `Benchmark*` in this tree. README still documents `go test -bench=BenchmarkProtectedEndpoint`: `README.md`, `knowledge/devdocs/build_testing_go.md`.
+- CRS image `BACKEND` default if omitted is still a proxy (`http://localhost:80`): `knowledge/research/ext_modsecurity_http-status_deny-vs-error/notes.md`. Overlay contract for replacing `proxy_pass` with inspect-only 200: not found in this tree (research in flight).
+
+## Desired
+
+- After ModSecurity **request** phases, the sidecar answers **HTTP 200** itself (GET and POST/PUT). Traefik `next` stays the real app.
+- Nginx: overlay `proxy_backend.conf.template` (mount `/etc/nginx/templates/includes/proxy_backend.conf.template`) so `location /` is method-agnostic 2xx, not `proxy_pass ${BACKEND}`. Keep `crs-nginx/realip.conf`. Keep cors include. Mount on every nginx compose that today sets dummy (`docker-compose.test.nginx.yml` at minimum).
+- Apache: edit existing `crs-apache/httpd-vhosts.conf` — remove ProxyPass family and websocket `[P]` to BACKEND_WS; keep RemoteIP / Unique-ID / X-Forwarded-Proto; add method-agnostic 200 **after** request processing (not a static file / POST 405).
+- Compose: delete unlabeled `dummy`; drop `BACKEND=http://dummy` once nothing interpolates it. Keep labeled whoami apps. Nginx `/` healthcheck must still pass.
+- Docs: rewrite dummy/always-200 as shadow WAF (sidecar inspect + 200; `next` is the app).
+- Prove on live CRS (Pester / curl through Traefik **and** curl at `waf:8080`): allow GET+POST body; URI CRS block; **POST-body CRS block** (abort nginx `return` if phase 2 is skipped); Range must not be sidecar 416; client-IP audit tests; no dummy service.
+- Fallback if `return 200` skips body rules: same-container loopback drain-200, still no extra compose service; document why `return` failed.
+- **Throughput (caller):** measure allow-path throughput **before** the overlay and **after**. Put before, after, and delta on the delivery card. Do not treat that as a license to add `Benchmark*` or bombardier CI unless measurement cannot be done otherwise.
+
+## Affected
+
+- `crs-apache/httpd-vhosts.conf`
+- new nginx overlay under `crs-nginx/` plus `docker-compose.test.nginx.yml` volume
+- `docker-compose.yml`, `docker-compose.local.yml`, `docker-compose.test.yml`, `docker-compose.test.nginx.yml`
+- `README.md` How-it-works dummy paragraph
+- usage packets that still call dummy the WAF origin (`knowledge/devdocs/build_testing_integration.md`; possibly `core_plugin_middleware.md` if dummy is named)
+- Pester integration suite (authority for overlays; Go unit tests mock the sidecar)
+
+## Out of scope
+
+- Changing `pkg/modsecurity/serve.go` (3xx/4xx-as-block, allow `< 300`, no new Config knob)
+- Pointing `BACKEND` at Traefik or the real app; `BACKEND=http://127.0.0.1:8080` loop; DetectionOnly as a substitute for dropping ProxyPass
+- Removing labeled whoami apps (`website-with-waf`, `whoami-protected`, …)
+- Dropping X-Real-IP / REMOTEIP / nginx real_ip overlays
+- Plugin `maxBodySizeBytes` default / README 5 MB (#20)
+- Durable allow-path CORS / Yaegi (#29)
+- In-process libmodsecurity
+- Committing new `Benchmark*` functions or bombardier CI (measure for the card; do not sneak a bench suite)
+
+## Unknowns
+
+- Whether nginx `return 200` in `location /` still runs CRS request-body inspection (phase 2) on pin `4.3.0-nginx-alpine-202406090906`.
+- Which Apache method-agnostic 200 (Lua `DONE`, CGI drain, other) actually runs after request phases on pin `4.3.0-apache-alpine-202406090906`.
+- Before-change allow-path throughput on this machine (not yet measured).
+- Official CRS Docker overlay paths for this pin vs `main` (research in flight).
+
+## Tensions
+
+- Brief says do not add bombardier benches; caller says measure throughput before and after and put improvement on the delivery card. This run measures and reports; it does not add a `Benchmark*` suite unless that is the only way to get the numbers.
+- Brief says this is compose + CRS overlay, not a plugin feature. README still documents `BenchmarkProtectedEndpoint`, which is not in the tree — not taken here.
+- Dummy whoami is both the CRS origin (remove) and the labeled app behind Traefik (keep). Only the unlabeled `dummy` service is in scope.

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/review.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/review.md
@@ -12,3 +12,11 @@ findings: nginx return 200 skips CRS (URI+body); Apache /healthz rewrite still i
 fixed: none
 skipped: overlay not implemented; after-change throughput not measured
 
+## propose (2026-09-03)
+
+phase: propose
+findings: none
+fixed: none
+skipped: overlay not implemented
+
+

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/review.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/review.md
@@ -1,0 +1,6 @@
+## prepare (2026-09-03)
+
+phase: prepare
+findings: none
+fixed: none
+skipped: CRS overlay not implemented; allow-path throughput not measured (before/after belongs on later cards)

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/review.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/review.md
@@ -20,3 +20,10 @@ fixed: none
 skipped: overlay not implemented
 
 
+
+## implement (2026-09-03)
+
+phase: implement
+findings: four-stack suite kept; nginx drain is loopback server not nc; Test-Integration finally leaked docker compose ps into exit code (fixed)
+fixed: inspect-only overlays; Pester benches all four stacks; runner exit code
+skipped: CI not seen on this head yet; code review not started

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/review.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/review.md
@@ -4,3 +4,11 @@ phase: prepare
 findings: none
 fixed: none
 skipped: CRS overlay not implemented; allow-path throughput not measured (before/after belongs on later cards)
+
+## explore (2026-09-03)
+
+phase: explore
+findings: nginx return 200 skips CRS (URI+body); Apache /healthz rewrite still inspects; Range 416 also on tiny 200
+fixed: none
+skipped: overlay not implemented; after-change throughput not measured
+

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/specs.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/specs.md
@@ -1,0 +1,6 @@
+# Specs
+change: inspect-only-crs-sidecar
+- added core_crs_sidecar_inspect-only (new)
+
+FindSpecHost:
+- delta inspect-only CRS sidecar: new `core_crs_sidecar_inspect-only` (high). Candidates: `core_plugin_middleware_sidecar-request`, `core_plugin_middleware_sidecar-response` (plugin Host/block copy — not compose overlay).

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/status-comment.json
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/status-comment.json
@@ -1,5 +1,5 @@
 {
-  "commentId": "pending-pr-body",
+  "commentId": "pr-body",
   "issueKey": "2026-09-03-remove-2nd-hop",
   "markerValue": "[sgsi-dev-ticket-status:2026-09-03-remove-2nd-hop]",
   "issueHost": "local"

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/status-comment.json
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/status-comment.json
@@ -1,0 +1,6 @@
+{
+  "commentId": "pending-pr-body",
+  "issueKey": "2026-09-03-remove-2nd-hop",
+  "markerValue": "[sgsi-dev-ticket-status:2026-09-03-remove-2nd-hop]",
+  "issueHost": "local"
+}

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/ticket/compact.yaml
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/ticket/compact.yaml
@@ -1,0 +1,5 @@
+host: local
+ref: none
+title: inspect-only CRS sidecar (drop dummy hop)
+url: none
+number: none

--- a/devstate/2026/09/2026-09-03-remove-2nd-hop/ticket/source.md
+++ b/devstate/2026/09/2026-09-03-remove-2nd-hop/ticket/source.md
@@ -1,0 +1,165 @@
+# inspect-only CRS sidecar (drop dummy hop)
+
+Local spec. Caller extras (chat, 2026-09-03):
+
+- Issue slug: remove-2nd-hop. IssueKey: 2026-09-03-remove-2nd-hop.
+- Use a dedicated git worktree.
+- Benchmark throughput BEFORE and AFTER the change. Put any improvement on the delivery card.
+
+Source brief: `modsecissues/inspect-only-sidecar.md` (scratch from chat explore, 2026-09-03).
+
+---
+
+# Implementer brief: inspect-only CRS sidecar (drop dummy hop)
+
+Scratch from chat explore (2026-09-03). Not an OpenSpec change yet. Start **sbs-dev-prepare** with a human `IssueKey` before product commits if you are in the eight-phase pipeline.
+
+**Goal:** stop the OWASP CRS container from `ProxyPass` / `proxy_pass` to a second `dummy` (whoami) service. After ModSecurity **request** phases, the sidecar itself answers **HTTP 200**. Traefik `next` remains the real app.
+
+This is **compose + CRS overlay**, not a plugin feature. Do **not** change `pkg/modsecurity/serve.go` for this.
+
+---
+
+## Why
+
+Allow path today:
+
+```
+Client → Traefik → plugin
+                     ├─ hop 1 (required): HTTP copy → CRS :8080
+                     │                         └─ hop 2 (drop this): ProxyPass → dummy whoami
+                     └─ hop 3 (required): next → real app
+```
+
+Hop 1 is the product (Yaegi cannot load libmodsecurity). Hop 2 is only the stock CRS Docker image (`BACKEND` → Apache `ProxyPass` / nginx `proxy_pass`). Dummy’s response is **not** the real app, so CRS phase 4 already does not protect the backend. Hop 2 still costs latency and causes:
+
+| Upstream issue (other repo) | How dummy hurts |
+|-----------------------------|-----------------|
+| #23 | Apache `AH01084` passing body to whoami; whoami echoes the full request |
+| #25 | Apache `416` when `Range` is larger than whoami; we copy sidecar 4xx as a block |
+| #27 | Operators confuse dummy with Traefik’s backend |
+
+Plugin keep-alive (#2) is already fixed (`discardSidecarBody`). This brief does **not** add bombardier benches and does **not** raise `maxBodySizeBytes` (#20).
+
+---
+
+## Do not
+
+- Add a plugin `Config` knob. `ServeHTTP` already treats sidecar `< 300` as allow.
+- Point `BACKEND` at Traefik or at the real app (second production request; app 3xx/4xx become WAF blocks — #19).
+- Set `BACKEND=http://127.0.0.1:8080` (loop).
+- Rely on omitting `BACKEND` — image default is `http://localhost:80` and still proxies.
+- Rely on `MODSEC_RULE_ENGINE=DetectionOnly` — that does not remove `ProxyPass`.
+- Use a static Apache `DocumentRoot` / `index.html` as the 200 handler — **POST often 405**. This plugin copies sidecar `3xx`/`4xx` as a **security block**. POST/PUT must return **2xx**.
+- Drop Traefik `X-Real-IP` trust (`REMOTEIP_*` / nginx `real_ip`). Existing client-IP audit tests depend on it.
+- Remove labeled whoami **apps** (`website-with-waf`, `whoami-protected`, …). Only the unlabeled **`dummy` CRS origin** goes away.
+
+---
+
+## How CRS Docker expects overlays
+
+Stock image is a reverse proxy. Official escape hatch is **file overlays**, not an env flag.
+
+**Nginx** (CRS Docker README): mount templates under `/etc/nginx/templates/` so `20-envsubst-on-templates.sh` still runs. Files in `templates/` keep subdirectory layout.
+
+Relevant stock files (image `main` / same shape on our 4.3.0 pin):
+
+- `nginx/templates/conf.d/modsecurity.conf.template` — `modsecurity on;` at **http** level (keep).
+- `nginx/templates/conf.d/default.conf.template` — `location /` includes `includes/proxy_backend.conf`.
+- `nginx/templates/includes/proxy_backend.conf.template` — `proxy_pass ${BACKEND};` plus `real_ip_*` (too late for CRS on 4.3.0 nginx pin).
+- `location /healthz` already `return 200 "OK"` without proxy.
+
+**Apache:** vhost is `/usr/local/apache2/conf/extra/httpd-vhosts.conf`. This repo **already mounts** `crs-apache/httpd-vhosts.conf` (RemoteIPHeader X-Real-IP). That overlay still has `ProxyPass / ${BACKEND}/ disablereuse=on`. Edit **that file**; do not add a parallel vhost.
+
+Pinned images in compose today:
+
+- Apache: `owasp/modsecurity-crs:4.3.0-apache-alpine-202406090906`
+- Nginx test: `owasp/modsecurity-crs:4.3.0-nginx-alpine-202406090906`
+
+---
+
+## Intended change
+
+### 1. Nginx overlay (smallest)
+
+New file, e.g. `crs-nginx/proxy_backend.conf.template` (name to match the image template), mounted to:
+
+`/etc/nginx/templates/includes/proxy_backend.conf.template`
+
+Replace `proxy_pass ${BACKEND};` with a method-agnostic 2xx, e.g.:
+
+```
+default_type text/plain;
+return 200 'ok';
+```
+
+Keep cors include via `default.conf` (do not drop `include includes/cors.conf`).
+
+**Keep** existing `crs-nginx/realip.conf` → `/etc/nginx/conf.d/zz-realip.conf`. On 4.3.0, `real_ip` inside `proxy_backend.conf` is **too late** for ModSecurity. If the new template still contains `real_ip_*`, http-level overlay still wins; do not remove `zz-realip.conf`.
+
+Mount this overlay on **every** nginx compose that today sets `BACKEND=http://dummy` (`docker-compose.test.nginx.yml` at minimum).
+
+### 2. Apache overlay
+
+Edit `crs-apache/httpd-vhosts.conf`:
+
+- Remove `ProxyPass` / `ProxyPassReverse` / `ProxyErrorOverride` / `ProxyTimeout` / `ProxyPreserveHost` / `ProxyRequests` if unused.
+- Remove websocket `RewriteRule` `[P]` to `${BACKEND_WS}`.
+- Leave `RemoteIPHeader X-Real-IP`, `RemoteIPInternalProxy ${REMOTEIP_INT_PROXY}`, Unique-ID / X-Forwarded-Proto request headers as they are (client-IP contract).
+- Add a **method-agnostic HTTP 200** after request processing (Lua `DONE`, CGI that discards stdin, or equivalent). **Not** a static file.
+
+`${BACKEND}` may remain in the environment unused, or compose can drop `BACKEND=` once nothing interpolates it. Do not leave a `ProxyPass` that still needs dummy.
+
+### 3. Compose
+
+On Apache and nginx compose files that have `dummy:` + `BACKEND=http://dummy`:
+
+- Delete the **`dummy` service** (unlabeled `traefik/whoami` used only as CRS origin).
+- Drop `BACKEND=http://dummy` if the overlay no longer references it.
+- Keep `waf` healthchecks working: nginx test compose currently probes `http://127.0.0.1:8080/` (not `/healthz`). Inspect-only `return 200` on `/` satisfies that.
+
+Files that set dummy today: `docker-compose.yml`, `docker-compose.local.yml`, `docker-compose.test.yml`, `docker-compose.test.nginx.yml` (and nginx twin if any).
+
+### 4. Docs
+
+README “dummy so the WAF forwards and always 200”: rewrite as **shadow WAF** — plugin copies the request to CRS; CRS inspects and 200s; Traefik `next` is the app. Language already in `knowledge/devdocs/core_plugin_middleware.md` (`sidecar request` vs `next`). Close the #27 mix-up.
+
+---
+
+## Must prove (or the change is wrong)
+
+Run against live CRS (Pester / curl through Traefik **and** curl straight at `waf:8080`):
+
+1. **Allow:** benign GET and **POST with a small body** → sidecar **200**, plugin calls `next`, app body/status unchanged.
+2. **Phase 1 block:** classic CRS probe in the **URI/query** (existing integration attack path) → sidecar **403** (or configured deny), `next` not called.
+3. **Phase 2 block (gate):** CRS probe in the **POST body** (not only the URL). If this becomes 200, nginx `return` skipped request-body inspection — **abort `return`**, use a handler that runs after access (or a loopback drain-200). Apache static 405 also fails this.
+4. **Range:** `Range: bytes=10240-` on a small GET must **not** become sidecar **416** (that was dummy/whoami). Expect 200 from sidecar, then backend 206/200 as today.
+5. **Client IP:** existing audit `REMOTE_ADDR` == Traefik `ClientHost` tests still pass (X-Real-IP overlays).
+6. **No dummy:** `docker compose ps` has no `dummy` service; `BACKEND` not required for a 200.
+
+Existing Go unit tests mock the sidecar; they will not catch a broken overlay. Integration suite is the authority.
+
+---
+
+## Fallback if `return 200` skips body rules
+
+Same-container **drain-200** on loopback (tiny process, `BACKEND=http://127.0.0.1:<internal>`), still **no** extra compose service. That is worse than inspect-only but still removes whoami and #23 echo. Document why `return` failed (phase 2).
+
+---
+
+## Out of scope (do not sneak in)
+
+- Plugin `maxBodySizeBytes` default / README 5 MB lie (#20)
+- Durable allow-path CORS header test / Yaegi (#29)
+- Bombardier vs upstream #2 (no `Benchmark*` in this tree)
+- In-process libmodsecurity
+- Changing 3xx/4xx-as-block in `serve.go`
+
+---
+
+## Suggested first spike (before a large compose sweep)
+
+1. Overlay nginx `proxy_backend.conf.template` only on `docker-compose.test.nginx.yml`.
+2. Prove gates 1–3 (especially **POST body** CRS hit) with `curl` at `waf:8080`.
+3. If phase 2 holds, mirror Apache overlay + drop `dummy` on Apache compose; run Pester.
+4. Then demo `docker-compose.yml` / `docker-compose.local.yml`.

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -30,7 +30,6 @@ services:
       - PARANOIA=1
       - ANOMALY_INBOUND=10
       - ANOMALY_OUTBOUND=5
-      - BACKEND=http://dummy
       # New in CRS 4
       - REPORTING_LEVEL=2
 
@@ -53,11 +52,8 @@ services:
       - REMOTEIP_HEADER=X-Real-IP
       - "REMOTEIP_INT_PROXY=10.0.0.0/8 172.16.0.0/12 192.168.0.0/16"
     volumes:
-      - ./crs-apache/httpd-vhosts.conf:/usr/local/apache2/conf/extra/httpd-vhosts.conf:ro
+      - ./crs-apache/httpd-vhosts.drain.conf:/usr/local/apache2/conf/extra/httpd-vhosts.conf:ro
 
-
-  dummy:
-    image: traefik/whoami
 
   website-with-waf:
     image: traefik/whoami

--- a/docker-compose.test.apache-drain.yml
+++ b/docker-compose.test.apache-drain.yml
@@ -1,0 +1,11 @@
+# Overlay on docker-compose.test.yml: Apache CRS inspect-only (no dummy hop).
+# Usage: docker compose -f docker-compose.test.yml -f docker-compose.test.apache-drain.yml up -d
+#        ./Test-Integration.ps1 -Stack apache-drain
+
+services:
+  dummy:
+    profiles:
+      - whoami-origin
+  waf:
+    volumes:
+      - ./crs-apache/httpd-vhosts.drain.conf:/usr/local/apache2/conf/extra/httpd-vhosts.conf:ro

--- a/docker-compose.test.nginx-drain.yml
+++ b/docker-compose.test.nginx-drain.yml
@@ -1,0 +1,14 @@
+# Overlay on docker-compose.test.nginx.yml: nginx CRS + loopback drain origin (no dummy hop).
+# Usage: docker compose -f docker-compose.test.nginx.yml -f docker-compose.test.nginx-drain.yml up -d
+#        ./Test-Integration.ps1 -Stack nginx-drain
+# BACKEND mapping replaces the whoami dummy URL. realip overlay stays on the base file.
+
+services:
+  dummy:
+    profiles:
+      - whoami-origin
+  waf:
+    environment:
+      BACKEND: http://127.0.0.1:18081
+    volumes:
+      - ./crs-nginx/drain-origin.conf:/etc/nginx/conf.d/zz-drain-origin.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       - PARANOIA=1
       - ANOMALY_INBOUND=10
       - ANOMALY_OUTBOUND=5
-      - BACKEND=http://dummy
       # New in CRS 4
       - REPORTING_LEVEL=2
 
@@ -51,10 +50,7 @@ services:
       - REMOTEIP_HEADER=X-Real-IP
       - "REMOTEIP_INT_PROXY=10.0.0.0/8 172.16.0.0/12 192.168.0.0/16"
     volumes:
-      - ./crs-apache/httpd-vhosts.conf:/usr/local/apache2/conf/extra/httpd-vhosts.conf:ro
-
-  dummy:
-    image: traefik/whoami
+      - ./crs-apache/httpd-vhosts.drain.conf:/usr/local/apache2/conf/extra/httpd-vhosts.conf:ro
 
   website-with-waf:
     image: traefik/whoami

--- a/knowledge/devdocs/build_ci_github.md
+++ b/knowledge/devdocs/build_ci_github.md
@@ -9,7 +9,7 @@ Pull requests to `main`, `master`, or `develop` run Go build/test, golangci-lint
 - Put PR Go checks in `.github/workflows/go.yml` and `.github/workflows/build.yml`. Both run `go build` on `ubuntu-latest` with Go 1.24. `go.yml` Test is `go test -race -v ./...`. `build.yml` Test stays `go test -v ./...`.
 - Put PR lint in `.github/workflows/golangci-lint.yml` (its own job, not a step on `go.yml`). That job runs `golangci/golangci-lint-action@v9` with golangci-lint v2.13 and Go 1.24. The Action reads root `.golangci.yml`.
 - Run the same lint locally with `golangci-lint run ./...` (v2) from the repo root. Do not pass `--config` unless you are pointing at that file.
-- Put Compose+Pester checks in `.github/workflows/integration-test.yml`. That job starts `docker-compose.test.yml`, waits on Traefik API / bypass / protected, then runs `./scripts/integration-tests.Tests.ps1` only.
+- Put Compose+Pester checks in `.github/workflows/integration-test.yml`. That job matrix starts each of the four stacks (`apache-whoami`, `nginx-whoami`, `apache-drain`, `nginx-drain`), waits on Traefik API / bypass / protected, installs bombardier, then runs `./scripts/integration-tests.Tests.ps1` only.
 - Cut a release by pushing a `v*.*.*` tag. `.github/workflows/release.yml` calls `softprops/action-gh-release` with generated notes. It does not run `go build` or lint.
 
 ## Key files
@@ -18,7 +18,7 @@ Pull requests to `main`, `master`, or `develop` run Go build/test, golangci-lint
 - `.github/workflows/build.yml` — PR: `go build -v .` then `go test -v ./...`.
 - `.github/workflows/golangci-lint.yml` — PR: dedicated `lint` job, golangci-lint v2.13.
 - `.golangci.yml` — golangci-lint v2 config (`version: "2"`, `linters.default: standard`).
-- `.github/workflows/integration-test.yml` — PR: Compose up, Pester, logs on failure, `down -v`.
+- `.github/workflows/integration-test.yml` — PR: four-stack matrix, Compose up, Pester (including bombardier benches), logs on failure, `down -v`.
 - `.github/workflows/release.yml` — tag `v*.*.*` → GitHub Release.
 
 ## Gotchas

--- a/knowledge/devdocs/build_testing_integration.md
+++ b/knowledge/devdocs/build_testing_integration.md
@@ -2,7 +2,16 @@
 
 ## Overview
 
-Pester v5 tests hit a live Traefik + ModSecurity + whoami stack. Apache CRS is `docker-compose.test.yml` (default). nginx CRS is `docker-compose.test.nginx.yml`. The local runner is `Test-Integration.ps1`. Helpers live in `scripts/TestHelpers.ps1`.
+Pester v5 tests hit a live Traefik + ModSecurity + whoami stack. Four named stacks:
+
+| Stack | Compose | CRS origin |
+| --- | --- | --- |
+| `apache-whoami` | `docker-compose.test.yml` | unlabeled `dummy` (`BACKEND=http://dummy`, Apache ProxyPass) |
+| `nginx-whoami` | `docker-compose.test.nginx.yml` | unlabeled `dummy` (`BACKEND=http://dummy`, nginx `proxy_pass`) |
+| `apache-drain` | `docker-compose.test.yml` + `docker-compose.test.apache-drain.yml` | inspect-only rewrite 200 (`httpd-vhosts.drain.conf`), no dummy |
+| `nginx-drain` | `docker-compose.test.nginx.yml` + `docker-compose.test.nginx-drain.yml` | loopback origin `127.0.0.1:18081` (`drain-origin.conf`), no dummy |
+
+The local runner is `Test-Integration.ps1`. Helpers live in `scripts/TestHelpers.ps1`.
 
 ## How to use
 
@@ -11,7 +20,7 @@ Pester v5 tests hit a live Traefik + ModSecurity + whoami stack. Apache CRS is `
 - Keep each `It` linear: setup → action → assert. Extract anything longer than a short sequence into `TestHelpers.ps1`.
 - Use `-Because` when the assertion reason is not obvious. Do not repeat `$BaseUrl` or readiness checks inside each `It`.
 - Send HTTP through `Invoke-SafeWebRequest`. Send chunked POSTs through `Invoke-ChunkedHttpRequest` (`Invoke-WebRequest` sets `Content-Length` and cannot hit `req.ContentLength == -1`). Use `Test-WafBlocking` / `Test-MaliciousPatterns` / `Test-BypassPatterns` for block/pass batches. Drive a live WebSocket through `Invoke-WebSocketEcho` (do not invent a second client).
-- Run the full local suite with `./Test-Integration.ps1` (default `-TestPath ./scripts/*.Tests.ps1`, `-ComposeFile ./docker-compose.test.yml`). Same suite on nginx: `./Test-Integration.ps1 -ComposeFile ./docker-compose.test.nginx.yml`.
+- Run one stack with `./Test-Integration.ps1` (default `apache-whoami`, `-TestPath ./scripts/*.Tests.ps1`). Same suite on another stack: `./Test-Integration.ps1 -Stack nginx-whoami` (or `apache-drain`, `nginx-drain`). All four, including bombardier benches: `./Test-Integration.ps1 -AllStacks`. Legacy: `-ComposeFile ./docker-compose.test.nginx.yml`.
 - Filter with `-PesterFullNameFilter` or `-PesterTagFilter`. Debug with `-SkipDockerCleanup` or `-SkipWait`.
 - Agents: `openspec/project.md` says delegate to `run-tests` (`run-tests integration`, `run-tests integration "<Suite Name>"`, `run-tests integration bodysize`, `run-tests integration tag <TagName>`).
 
@@ -34,18 +43,20 @@ It "Should allow normal GET requests" {
 
 ## Key files
 
-- `Test-Integration.ps1` — Compose up, optional wait, `Invoke-Pester`, Compose down.
-- `scripts/integration-tests.Tests.ps1` — main suite (`$BaseUrl` `http://localhost:8000`).
+- `Test-Integration.ps1` — Compose up, optional wait, `Invoke-Pester`, Compose down. `-Stack` / `-AllStacks` set `INTEGRATION_STACK`.
+- `scripts/integration-tests.Tests.ps1` — main suite (`$BaseUrl` `http://localhost:8000`). Drain-only Its (no dummy, Range not 416) skip on whoami stacks; dummy-present skips on drain. `Allow-path throughput` runs bombardier `-c 50 -d 15s` GET and POST `/protected` when `bombardier` is on PATH (`Invoke-AllowPathBombardier`); asserts req/s > 0 and prints `BENCH stack=...`.
 - `scripts/integration-tests.BodySize.Tests.ps1` — large-body transport checks.
-- `scripts/TestHelpers.ps1` — HTTP, WAF assertions, container names, access-log parse, WAF audit-log parse, body builder, Traefik stdout / reclaim log parse, WebSocket echo. Helpers include `Invoke-SafeWebRequest`, `Invoke-TcpHttpRequest`, `Invoke-ChunkedHttpRequest`, `Invoke-WebSocketEcho`, `Test-WafBlocking`, `Get-TraefikAccessLogEntries`, `Get-TraefikClientHost`, `Get-WafAuditLogRecords`, `Get-WafAuditClientIp`, `Get-WafAuditHost`, `Get-TraefikStdoutLines`, `Get-ReclaimLogEvents`, `Wait-ReclaimLogCount`, `Set-ReclaimDynamicTimeoutMillis`.
-- `docker-compose.test.yml` — Traefik local plugin on `:8000`, Apache CRS WAF, dummy, labeled whoami routes, `echo-ws` (`jmalloc/echo-server`) on `/ws-echo` behind `waf-middleware`, file-provider directory `test-dynamic/`. The `waf` service sets `REMOTEIP_HEADER=X-Real-IP`, RFC1918 `REMOTEIP_INT_PROXY`, and `MODSEC_AUDIT_LOG=/var/log/modsec_audit.log` so a deny records Traefik `ClientHost` as `REMOTE_ADDR`.
-- `docker-compose.test.nginx.yml` — same Traefik/plugin/routes; `waf` is nginx CRS with `REAL_IP_HEADER=X-Real-IP` and comma-separated RFC1918 `SET_REAL_IP_FROM`.
+- `scripts/TestHelpers.ps1` — HTTP, WAF assertions, container names, access-log parse, WAF audit-log parse, body builder, Traefik stdout / reclaim log parse, WebSocket echo, stack compose-file map, origin kind, bombardier. Helpers include `Invoke-SafeWebRequest`, `Invoke-TcpHttpRequest`, `Invoke-ChunkedHttpRequest`, `Invoke-WebSocketEcho`, `Test-WafBlocking`, `Get-TraefikAccessLogEntries`, `Get-TraefikClientHost`, `Get-WafAuditLogRecords`, `Get-WafAuditClientIp`, `Get-WafAuditHost`, `Get-TraefikStdoutLines`, `Get-ReclaimLogEvents`, `Wait-ReclaimLogCount`, `Set-ReclaimDynamicTimeoutMillis`, `Get-DummyContainerName`, `Get-IntegrationStackComposeFiles`, `Get-IntegrationOriginKind`, `Invoke-AllowPathBombardier`.
+- `docker-compose.test.yml` — Traefik local plugin on `:8000`, Apache CRS WAF, dummy whoami origin, labeled whoami routes, `echo-ws` (`jmalloc/echo-server`) on `/ws-echo` behind `waf-middleware`, file-provider directory `test-dynamic/`. The `waf` service sets `REMOTEIP_HEADER=X-Real-IP`, RFC1918 `REMOTEIP_INT_PROXY`, and `MODSEC_AUDIT_LOG=/var/log/modsec_audit.log` so a deny records Traefik `ClientHost` as `REMOTE_ADDR`.
+- `docker-compose.test.nginx.yml` — same Traefik/plugin/routes; `waf` is nginx CRS with `BACKEND=http://dummy`, `REAL_IP_HEADER=X-Real-IP` and comma-separated RFC1918 `SET_REAL_IP_FROM`.
+- `docker-compose.test.apache-drain.yml` — overlay: dummy `profiles: [whoami-origin]`, Apache inspect-only vhost.
+- `docker-compose.test.nginx-drain.yml` — overlay: dummy profiled off, `BACKEND=http://127.0.0.1:18081`, `crs-nginx/drain-origin.conf`.
 - `test-dynamic/reclaim.yml` — two routers (`/reclaim-a`, `/reclaim-b`) share `waf-reclaim` (`logLevel=debug`). Tests rewrite `timeoutMillis` to force a new reclaim key.
 
 ## Gotchas
 
 - Prerequisites observed in `README.md` and the runner: Docker, Compose, PowerShell 7+, Pester v5. The runner installs Pester if the module is missing.
-- CI (`.github/workflows/integration-test.yml`) runs `./scripts/integration-tests.Tests.ps1` on both Apache and nginx compose files (matrix). A BodySize-only change will pass CI unless you also cover it in the main file or change that workflow.
+- CI (`.github/workflows/integration-test.yml`) runs `./scripts/integration-tests.Tests.ps1` on a four-stack matrix (`apache-whoami`, `nginx-whoami`, `apache-drain`, `nginx-drain`) and installs bombardier. A BodySize-only change will pass CI unless you also cover it in the main file or change that workflow. Local benches need `bombardier` on PATH (`go install github.com/codesenberg/bombardier@latest`); the Its skip if it is missing.
 - Container helpers match `*-traefik-1` and `*-waf-1` so compose project names (local vs CI) still resolve.
 - Protected middleware in `docker-compose.test.yml` sets `maxBodySizeBytes=1024` on `/protected`. Do not assume the Go `CreateConfig` default (8 MiB) on that route.
 - Reclaim stdout tests need a fresh Traefik (`docker logs` is cumulative). Do not change `/protected` labels to force a new core; rewrite `test-dynamic/reclaim.yml` via `Set-ReclaimDynamicTimeoutMillis`. After a rewrite, `touch` the file in the container so file-watch fires on bind mounts. `DefaultGrace` is 10s; wait longer than that for `reclaim_dispose`.

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/apache-configuring-env.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/apache-configuring-env.md
@@ -1,0 +1,12 @@
+---
+url: https://httpd.apache.org/docs/2.4/configuring.html
+title: Apache HTTP Server — configuration file ${VAR} expansion
+fetched: 2026-09-03
+authority: official
+---
+
+Values of `Define` variables or shell environment variables can be used in configuration lines as `${VAR}`. If VAR is valid, its value is substituted. `Define` wins over the shell environment. If VAR is missing, `${VAR}` is left unchanged and a warning is logged.
+
+Only shell environment variables defined **before** the server starts are usable. `SetEnv` in the config is too late.
+
+CRS Apache vhost `${BACKEND}` / `${BACKEND_WS}` rely on this (image `ENV` + compose `-e`).

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/apache-core-default-handler.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/apache-core-default-handler.md
@@ -1,0 +1,15 @@
+---
+url: https://github.com/apache/httpd/blob/trunk/server/core.c
+title: Apache httpd default_handler — POST on a regular file
+fetched: 2026-09-03
+authority: source
+---
+
+`default_handler` (static content):
+
+- `ap_allow_standard_methods(..., M_GET, M_OPTIONS, M_POST, -1)`.
+- Discards the request body (`ap_discard_request_body`).
+- For `M_GET` or `M_POST`, opens the file. If method is not GET and `deliver_script` is unset: log APLOGNO(00131) “This resource does not accept the %s method.” and `return HTTP_METHOD_NOT_ALLOWED` (405).
+- Comment: the only possible non-GET method at that point is POST; only GET normally returns content.
+
+Same `M_POST` / `HTTP_METHOD_NOT_ALLOWED` branch is present on the 2.4.x `server/core.c` tree.

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/apache-vhosts-locations.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/apache-vhosts-locations.md
@@ -1,0 +1,11 @@
+---
+url: https://github.com/coreruleset/modsecurity-crs-docker/blob/5e3cda3ee7d0e77d70e550df7298c80269776cde/apache/conf/extra/httpd-vhosts.conf
+title: CRS Docker Apache vhost and /healthz locations
+fetched: 2026-09-03
+authority: source
+ref: coreruleset/modsecurity-crs-docker@5e3cda3ee7d0e77d70e550df7298c80269776cde:apache/conf/extra/httpd-vhosts.conf
+---
+
+`httpd-vhosts.conf`: no DocumentRoot. `ProxyPass / ${BACKEND}/ disablereuse=on`, `ProxyPassReverse / ${BACKEND}/`. Websocket: `RewriteCond` Upgrade/Connection, `RewriteRule .* "${BACKEND_WS}%{REQUEST_URI}" [P]`. `${REMOTEIP_HEADER}` (current tree; this product’s 4.3.0 overlay hardcodes `X-Real-IP` instead).
+
+`httpd-locations.conf`: `<Location "/healthz">` `RewriteRule .* - [R=200,L]`, `ErrorDocument 200 "OK"`, `ProxyPass !`.

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/crs-docker-readme.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/crs-docker-readme.md
@@ -1,0 +1,17 @@
+---
+url: https://github.com/coreruleset/modsecurity-crs-docker/blob/5e3cda3ee7d0e77d70e550df7298c80269776cde/README.md
+title: OWASP CRS Docker Image README
+fetched: 2026-09-03
+authority: official
+ref: coreruleset/modsecurity-crs-docker@5e3cda3ee7d0e77d70e550df7298c80269776cde:README.md
+---
+
+Nginx overlay: mount a local file as `/etc/nginx/templates/conf.d/default.conf.template`. Files in the templates directory are copied; subdirectories are preserved. Kubernetes error names `/docker-entrypoint.d/20-envsubst-on-templates.sh`.
+
+Common ENV `BACKEND`: Partial URL for the remote server of `ProxyPass` (httpd) and `proxy_pass` (nginx). Table default `http://localhost:80` (nginx column `-`).
+
+Apache ENV `BACKEND_WS`: WebSocket service URL. Default `ws://localhost:8081`.
+
+Container Health Checks: images return HTTP status 200 from `/healthz`.
+
+Proxy Configuration: default configuration (no file overrides) acts as a reverse proxy and requires a running backend at `BACKEND`. If `BACKEND` is not an address where a web server is listening, nothing useful happens with the default configuration.

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/dockerfile-backend-env.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/dockerfile-backend-env.md
@@ -1,0 +1,15 @@
+---
+url: https://github.com/coreruleset/modsecurity-crs-docker/blob/5e3cda3ee7d0e77d70e550df7298c80269776cde/nginx/Dockerfile-alpine
+title: CRS Docker image ENV BACKEND defaults and overlay copy paths
+fetched: 2026-09-03
+authority: source
+ref: coreruleset/modsecurity-crs-docker@5e3cda3ee7d0e77d70e550df7298c80269776cde:nginx/Dockerfile-alpine
+---
+
+nginx Dockerfiles: `ENV BACKEND=http://localhost:80`, `NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx`. `COPY nginx/templates /etc/nginx/templates/`. Comment: “We use the templating mechanism from the nginx image here.”
+
+`apache/Dockerfile`: `BACKEND=http://localhost:80`, `BACKEND_WS=ws://localhost:8081`.
+
+`apache/Dockerfile-alpine`: `BACKEND=http://localhost:8080`, `BACKEND_WS=ws://localhost:8081`. `COPY apache/conf/extra/*.conf /usr/local/apache2/conf/extra/`. Enables `Include conf/extra/httpd-vhosts.conf`; appends `httpd-locations.conf` and `httpd-modsecurity.conf`.
+
+`docker-bake.hcl`: `modsecurity-nginx-version` default `1.0.4`; nginx dynamic module `owasp-modsecurity/ModSecurity-nginx` at `v${modsecurity-nginx-version}`.

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/healthcheck.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/healthcheck.md
@@ -1,0 +1,13 @@
+---
+url: https://github.com/coreruleset/modsecurity-crs-docker/blob/5e3cda3ee7d0e77d70e550df7298c80269776cde/src/bin/healthcheck
+title: CRS Docker image HEALTHCHECK script
+fetched: 2026-09-03
+authority: source
+ref: coreruleset/modsecurity-crs-docker@5e3cda3ee7d0e77d70e550df7298c80269776cde:src/bin/healthcheck
+---
+
+Comment: “Endpoint /healthz should always return 200.”
+
+`curl -sk -A healthcheck` to `${scheme}://${host}:${port}/healthz`. Default scheme https / `SSL_PORT`. Apache with `SSL_ENGINE=off` uses http / `PORT`.
+
+Dockerfiles set `HEALTHCHECK CMD /usr/local/bin/healthcheck`.

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/modsecurity-nginx-v1.0.4.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/modsecurity-nginx-v1.0.4.md
@@ -1,0 +1,17 @@
+---
+url: https://github.com/owasp-modsecurity/ModSecurity-nginx/blob/v1.0.4/src/ngx_http_modsecurity_module.c
+title: ModSecurity-nginx v1.0.4 phase hooks and request-body handler
+fetched: 2026-09-03
+authority: source
+ref: owasp-modsecurity/ModSecurity-nginx@v1.0.4:src/ngx_http_modsecurity_module.c
+---
+
+`ngx_http_modsecurity_init` registers:
+
+- `NGX_HTTP_REWRITE_PHASE` → `ngx_http_modsecurity_rewrite_handler` (comment: cannot hook FIND_CONFIG; next option is REWRITE).
+- `NGX_HTTP_PREACCESS_PHASE` → `ngx_http_modsecurity_pre_access_handler` (comment: “Processing the request body on the preaccess phase.”).
+- `NGX_HTTP_LOG_PHASE` → `ngx_http_modsecurity_log_handler`.
+
+`ngx_http_modsecurity_pre_access.c`: if `modsecurity` enabled, calls `ngx_http_read_client_request_body`, appends buffers or `msc_request_body_from_file`, then `msc_process_request_body`. That is the phase-2 / request-body path on this tag.
+
+Current CRS docker bake (`5e3cda3`) sets `modsecurity-nginx-version` to `1.0.4`. The 4.3.0 image pin was not opened.

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/nginx-docker-hub-templates.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/nginx-docker-hub-templates.md
@@ -1,0 +1,12 @@
+---
+url: https://hub.docker.com/_/nginx
+title: Docker Hub official nginx — environment variables in configuration
+fetched: 2026-09-03
+authority: official
+---
+
+Since 1.19, the image runs envsubst on templates before nginx starts. Default: read `/etc/nginx/templates/*.template`, write to `/etc/nginx/conf.d` (suffix stripped).
+
+`NGINX_ENVSUBST_TEMPLATE_DIR` default `/etc/nginx/templates`. `NGINX_ENVSUBST_OUTPUT_DIR` default `/etc/nginx/conf.d`. Output filename is the template name without suffix; subdirectory layout is preserved relative to the template dir when OUTPUT_DIR is changed.
+
+Script on the image: `/docker-entrypoint.d/20-envsubst-on-templates.sh` (named by CRS README).

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/nginx-http-phases.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/nginx-http-phases.md
@@ -1,0 +1,16 @@
+---
+url: https://nginx.org/en/docs/dev/development_guide.html#http_phases
+title: nginx development guide — HTTP request phases
+fetched: 2026-09-03
+authority: official
+---
+
+Phases run successively. Relevant order:
+
+- `NGX_HTTP_REWRITE_PHASE` — rewrite rules in the chosen location (`ngx_http_rewrite_module`).
+- `NGX_HTTP_PREACCESS_PHASE` — e.g. limit_conn / limit_req.
+- `NGX_HTTP_ACCESS_PHASE` — access / auth.
+- `NGX_HTTP_CONTENT_PHASE` — response generation (index/static).
+- `NGX_HTTP_LOG_PHASE` — logging at the end.
+
+`return` is a rewrite-module directive (see nginx-return.md), so it is evaluated in rewrite, before preaccess/access/content.

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/nginx-return.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/nginx-return.md
@@ -1,0 +1,12 @@
+---
+url: https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
+title: nginx ngx_http_rewrite_module return
+fetched: 2026-09-03
+authority: official
+---
+
+Context: `server`, `location`, `if`.
+
+`return code [text]` / `return code URL` / `return URL`: stops processing and returns the specified code to a client.
+
+Rewrite-module directives (`break`, `if`, `return`, `rewrite`, `set`) are processed as: server-level rewrite directives, then location search, then location-level rewrite directives.

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/nginx-templates-backend.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/nginx-templates-backend.md
@@ -1,0 +1,17 @@
+---
+url: https://github.com/coreruleset/modsecurity-crs-docker/blob/5e3cda3ee7d0e77d70e550df7298c80269776cde/nginx/templates/includes/proxy_backend.conf.template
+title: CRS Docker nginx proxy and location templates
+fetched: 2026-09-03
+authority: source
+ref: coreruleset/modsecurity-crs-docker@5e3cda3ee7d0e77d70e550df7298c80269776cde:nginx/templates/includes/proxy_backend.conf.template
+---
+
+`proxy_backend.conf.template`: `proxy_set_header` Host/Upgrade/Connection/`REAL_IP_PROXY_HEADER`/X-Forwarded-*; `proxy_pass ${BACKEND};` then real_ip placeholders. No `BACKEND_WS`.
+
+`conf.d/default.conf.template`: both servers `location / { include includes/proxy_backend.conf; index index.html index.htm; root /usr/share/nginx/html; }` then `include includes/location_common.conf`.
+
+`includes/location_common.conf.template`: `location /healthz { access_log off; add_header Content-Type text/plain; return 200 "OK"; }` — no `proxy_pass`, no `modsecurity off`.
+
+`conf.d/modsecurity.conf.template`: `modsecurity on;` and `modsecurity_rules_file /etc/modsecurity.d/setup.conf;` (http-level via `conf.d`).
+
+`nginx.conf.template`: `http { include /etc/nginx/conf.d/*.conf; }`.

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/this-repo-4.3.0-pin.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/.sources/this-repo-4.3.0-pin.md
@@ -1,0 +1,12 @@
+---
+url: file://crs-apache/httpd-vhosts.conf
+title: This worktree 4.3.0 pin overlay and compose BACKEND
+fetched: 2026-09-03
+authority: source
+---
+
+`crs-apache/httpd-vhosts.conf` header: overlay for `owasp/modsecurity-crs:4.3.0-apache-alpine-202406090906`; “this copy is the image vhost” with RemoteIPHeader changed to X-Real-IP. Same `ProxyPass / ${BACKEND}/` and `RewriteRule .* "${BACKEND_WS}%{REQUEST_URI}" [P]` as current CRS `httpd-vhosts.conf`. No DocumentRoot.
+
+`docker-compose.yml`, `docker-compose.local.yml`, `docker-compose.test.yml`: image `4.3.0-apache-alpine-202406090906`, `BACKEND=http://dummy`, volume `./crs-apache/httpd-vhosts.conf:/usr/local/apache2/conf/extra/httpd-vhosts.conf:ro`.
+
+`docker-compose.test.nginx.yml`: image `4.3.0-nginx-alpine-202406090906`, `BACKEND=http://dummy`. Overlay is only `crs-nginx/realip.conf` → `/etc/nginx/conf.d/zz-realip.conf` (real_ip, not BACKEND).

--- a/knowledge/research/ext_modsecurity_crs-docker_backend/notes.md
+++ b/knowledge/research/ext_modsecurity_crs-docker_backend/notes.md
@@ -1,0 +1,145 @@
+# CRS Docker BACKEND
+
+Official `owasp/modsecurity-crs` images are reverse proxies. `BACKEND` / `BACKEND_WS` select the next hop. This folder is the inspect-only / overlay contract for dropping that hop (ticket `2026-09-03-remove-2nd-hop`).
+
+This product’s pins are `owasp/modsecurity-crs:4.3.0-apache-alpine-202406090906` and `4.3.0-nginx-alpine-202406090906`. Templates below were read from `coreruleset/modsecurity-crs-docker@5e3cda3` (2026-08-19). The 4.3.0 pin was not docker-inspected; this worktree’s Apache overlay is a copy of that pin’s vhost and still uses the same `ProxyPass` / `BACKEND_WS` lines.
+
+Do not duplicate [CRS Docker nginx real_ip env](../ext_modsecurity_crs-docker_nginx-real-ip/notes.md).
+
+## BACKEND and BACKEND_WS
+
+Official README Common ENV: `BACKEND` is the “Partial URL for the remote server of the `ProxyPass` (httpd) and `proxy_pass` (nginx) directives.” Table default: `http://localhost:80` (nginx column is “-”, same as httpd).
+
+Owner: [CRS Docker README — Common ENV Variables](https://github.com/coreruleset/modsecurity-crs-docker/blob/5e3cda3ee7d0e77d70e550df7298c80269776cde/README.md). Extract: `.sources/crs-docker-readme.md`.
+
+Image `ENV` when `BACKEND` is omitted (current tree):
+
+| Image Dockerfile | `BACKEND` | `BACKEND_WS` |
+| --- | --- | --- |
+| `nginx/Dockerfile`, `nginx/Dockerfile-alpine` | `http://localhost:80` | (none) |
+| `apache/Dockerfile` | `http://localhost:80` | `ws://localhost:8081` |
+| `apache/Dockerfile-alpine` | `http://localhost:8080` | `ws://localhost:8081` |
+
+Official README vs alpine Apache `ENV`: conflict. Follow **source** for what the alpine image starts with (`http://localhost:8080`). README still says `http://localhost:80`. This product’s alpine pin was not opened; current alpine Dockerfile is the owner for today’s alpine default.
+
+Owner: `coreruleset/modsecurity-crs-docker@5e3cda3:nginx/Dockerfile-alpine`, `apache/Dockerfile-alpine`, `apache/Dockerfile`. Extract: `.sources/dockerfile-backend-env.md`.
+
+Apache vhost uses both:
+
+```
+ProxyPass / ${BACKEND}/ disablereuse=on
+ProxyPassReverse / ${BACKEND}/
+RewriteRule .* "${BACKEND_WS}%{REQUEST_URI}" [P]
+```
+
+(`RewriteCond` Upgrade/Connection websocket.) Apache expands `${BACKEND}` / `${BACKEND_WS}` from the process environment.
+
+Owner: `coreruleset/modsecurity-crs-docker@5e3cda3:apache/conf/extra/httpd-vhosts.conf`; [Apache configuration files — `${VAR}`](https://httpd.apache.org/docs/2.4/configuring.html). Extracts: `.sources/apache-vhosts-locations.md`, `.sources/apache-configuring-env.md`.
+
+nginx `location /` includes `includes/proxy_backend.conf`, which ends with `proxy_pass ${BACKEND};`. There is no `BACKEND_WS` on nginx; WebSocket uses `proxy_set_header Upgrade` / `Connection` on the same `proxy_pass`.
+
+Owner: `coreruleset/modsecurity-crs-docker@5e3cda3:nginx/templates/includes/proxy_backend.conf.template`, `nginx/templates/conf.d/default.conf.template`. Extract: `.sources/nginx-templates-backend.md`.
+
+Official Proxy Configuration: default images “act as reverse proxies and require a running backend at the address specified through the `BACKEND` environment variable.” If `BACKEND` is unset or nothing listens there, “nothing useful will happen” unless configuration is overridden.
+
+Owner: [CRS Docker README — Proxy Configuration](https://github.com/coreruleset/modsecurity-crs-docker/blob/5e3cda3ee7d0e77d70e550df7298c80269776cde/README.md).
+
+## Overlay mount paths
+
+### nginx — `/etc/nginx/templates/` and `20-envsubst-on-templates.sh`
+
+CRS nginx images are based on upstream nginx. The README escape hatch: mount a replacement as a **template**, e.g. local `nginx/default.conf` → `/etc/nginx/templates/conf.d/default.conf.template`. “Files in the templates directory will be copied and subdirectories will be preserved.” Kubernetes note names `/docker-entrypoint.d/20-envsubst-on-templates.sh` (the official nginx image script).
+
+Owner: [CRS Docker README — Nginx based images breaking change](https://github.com/coreruleset/modsecurity-crs-docker/blob/5e3cda3ee7d0e77d70e550df7298c80269776cde/README.md).
+
+Official nginx image: templates under `/etc/nginx/templates/` with suffix `.template` are `envsubst`’d. Default output dir is `/etc/nginx/conf.d`. CRS sets `NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx`, so the template tree maps 1:1 under `/etc/nginx/`.
+
+Exact overlay paths for this image:
+
+| Replace | Mount this template | Written file |
+| --- | --- | --- |
+| `proxy_pass` / proxy headers | `/etc/nginx/templates/includes/proxy_backend.conf.template` | `/etc/nginx/includes/proxy_backend.conf` |
+| whole `location /` (and servers) | `/etc/nginx/templates/conf.d/default.conf.template` | `/etc/nginx/conf.d/default.conf` |
+
+Owner: [Docker Hub nginx — Using environment variables](https://hub.docker.com/_/nginx); `coreruleset/modsecurity-crs-docker@5e3cda3:nginx/Dockerfile-alpine` (`NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx`). Extracts: `.sources/nginx-docker-hub-templates.md`, `.sources/dockerfile-backend-env.md`.
+
+### Apache — vhost path (no templates dir)
+
+`COPY apache/conf/extra/*.conf /usr/local/apache2/conf/extra/`. `httpd.conf` includes `conf/extra/httpd-vhosts.conf`. Overlay the **installed** file:
+
+`/usr/local/apache2/conf/extra/httpd-vhosts.conf`
+
+Keep `${ENV}` placeholders; Apache substitutes them. This worktree already mounts `./crs-apache/httpd-vhosts.conf` at that path.
+
+Owner: `coreruleset/modsecurity-crs-docker@5e3cda3:apache/Dockerfile-alpine`; this worktree `docker-compose.yml` / `crs-apache/httpd-vhosts.conf`. Extracts: `.sources/dockerfile-backend-env.md`, `.sources/this-repo-4.3.0-pin.md`.
+
+`/healthz` lives in `httpd-locations.conf`, not the vhost. Replacing only the vhost leaves `/healthz` in place.
+
+## nginx `return 200` and ModSecurity phase 2
+
+**Official CRS / nginx docs do not say** whether `return 200` in `location /` still runs ModSecurity request-body inspection. The following is **authority: inference** from files read.
+
+CRS nginx enables ModSecurity at **http** level, not inside `location /`:
+
+```
+modsecurity on;
+modsecurity_rules_file /etc/modsecurity.d/setup.conf;
+```
+
+That file is `nginx/templates/conf.d/modsecurity.conf.template` → `/etc/nginx/conf.d/modsecurity.conf`, included by `nginx.conf` (`include /etc/nginx/conf.d/*.conf` inside `http`). `/healthz` does **not** set `modsecurity off`.
+
+Owner: `coreruleset/modsecurity-crs-docker@5e3cda3:nginx/templates/conf.d/modsecurity.conf.template`, `nginx/templates/nginx.conf.template`, `nginx/templates/includes/location_common.conf.template`. Extract: `.sources/nginx-templates-backend.md`.
+
+Current bake pins the connector at **ModSecurity-nginx v1.0.4**. That tag registers:
+
+- request headers / phase 1: `NGX_HTTP_REWRITE_PHASE` → `ngx_http_modsecurity_rewrite_handler`
+- request body / phase 2: `NGX_HTTP_PREACCESS_PHASE` → `ngx_http_modsecurity_pre_access_handler` (`ngx_http_read_client_request_body`, then `msc_process_request_body`)
+
+Owner: `owasp-modsecurity/ModSecurity-nginx@v1.0.4:src/ngx_http_modsecurity_module.c`, `…/ngx_http_modsecurity_pre_access.c`; `coreruleset/modsecurity-crs-docker@5e3cda3:docker-bake.hcl` (`modsecurity-nginx-version = 1.0.4`). Extract: `.sources/modsecurity-nginx-v1.0.4.md`.
+
+Official nginx: `return` “Stops processing and returns the specified `code` to a client.” Rewrite-module directives (including `return`) run in the location rewrite phase. Official phase order: `REWRITE` → `PREACCESS` → `ACCESS` → content.
+
+Owner: [ngx_http_rewrite_module `return`](https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return); [nginx development guide — HTTP phases](https://nginx.org/en/docs/dev/development_guide.html#http_phases). Extracts: `.sources/nginx-return.md`, `.sources/nginx-http-phases.md`.
+
+**Inference:** `return 200` in `location /` finalizes in rewrite and does not reach `NGX_HTTP_PREACCESS_PHASE`. On v1.0.4 that is the only hook that reads the body and calls `msc_process_request_body`. So an inspect-only overlay that replaces `proxy_pass` with `return 200` is not documented to run phase 2; the files above imply it skips it. Whether the rewrite-phase handler (phase 1) still runs depends on handler order inside `REWRITE`; official docs do not say. The 4.3.0 pin’s connector tag was not read from the image.
+
+Vendor GitHub comments (not owners) report the same skip; they must not override the above.
+
+## Apache DocumentRoot / `index.html` and POST 405
+
+CRS Apache vhost has **no** `DocumentRoot` / `DirectoryIndex`. Default config is `ProxyPass /`, not a static site.
+
+Owner: `coreruleset/modsecurity-crs-docker@5e3cda3:apache/conf/extra/httpd-vhosts.conf`.
+
+Apache `default_handler` (static files): for `POST`, if `deliver_script` is unset (normal file, not a script handler), it logs “This resource does not accept the %s method.” and returns `HTTP_METHOD_NOT_ALLOWED` (**405**). GET is served. OPTIONS is handled separately.
+
+Owner: [apache/httpd `server/core.c` `default_handler`](https://github.com/apache/httpd/blob/trunk/server/core.c) (read 2026-09-03; same `M_POST` / `HTTP_METHOD_NOT_ALLOWED` branch on the 2.4.x tree). Extract: `.sources/apache-core-default-handler.md`.
+
+**Inference:** if `ProxyPass /` is removed and the request is handled as a regular file under the base image `DocumentRoot` (`index.html`), POST returns 405 after Apache has already run earlier request hooks. Official CRS docs do not describe that overlay. This product treats sidecar 3xx/4xx as a WAF block (ticket context, not a CRS fact).
+
+## `/healthz` — 200 without proxy (nginx)
+
+nginx `includes/location_common.conf` (included from both HTTP and SSL servers, **sibling** of `location /`, so it is not `proxy_pass`’d):
+
+```
+location /healthz {
+    access_log off;
+    add_header Content-Type text/plain;
+    return 200 "OK";
+}
+```
+
+README: images return HTTP 200 from `/healthz`. Image `HEALTHCHECK` curls `/healthz`.
+
+Owner: `coreruleset/modsecurity-crs-docker@5e3cda3:nginx/templates/includes/location_common.conf.template`; README “Container Health Checks”; `src/bin/healthcheck`. Extracts: `.sources/nginx-templates-backend.md`, `.sources/crs-docker-readme.md`, `.sources/healthcheck.md`.
+
+Apache parallel (not requested, same script): `<Location "/healthz">` uses `RewriteRule .* - [R=200,L]`, `ErrorDocument 200 "OK"`, `ProxyPass !`.
+
+Owner: `coreruleset/modsecurity-crs-docker@5e3cda3:apache/conf/extra/httpd-locations.conf`.
+
+## Unknowns
+
+- Exact `BACKEND` default and ModSecurity-nginx tag **inside** `4.3.0-*-202406090906` (image not pulled).
+- Official statement that `return` does or does not run phase 2 — none found; inference only.
+- Whether phase 1 still runs on a `return 200` `location /` (rewrite-handler order).
+- Measured POST status if this pin’s `DocumentRoot`/`index.html` is used without `ProxyPass` (source says 405 for static files; not runtime-tested).

--- a/knowledge/research/index_ext_modsecurity.md
+++ b/knowledge/research/index_ext_modsecurity.md
@@ -20,6 +20,11 @@ priority: normal
 local: ext_modsecurity_crs-docker_nginx-real-ip/
 description: Official owasp/modsecurity-crs nginx image env vars for real_ip (REAL_IP_HEADER, SET_REAL_IP_FROM, REAL_IP_RECURSIVE) and audit log path.
 
+## CRS Docker BACKEND
+priority: normal
+local: ext_modsecurity_crs-docker_backend/
+description: Official owasp/modsecurity-crs reverse-proxy BACKEND/BACKEND_WS wiring, overlay mount paths, and inspect-only response behavior.
+
 ## Host
 priority: normal
 local: ext_modsecurity_variables_host/

--- a/openspec/changes/inspect-only-crs-sidecar/.openspec.yaml
+++ b/openspec/changes/inspect-only-crs-sidecar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/inspect-only-crs-sidecar/design.md
+++ b/openspec/changes/inspect-only-crs-sidecar/design.md
@@ -1,0 +1,43 @@
+## Context
+
+See proposal.md Why. Stock `owasp/modsecurity-crs` 4.3.0 pins reverse-proxy to `BACKEND` (Apache `ProxyPass`, nginx `proxy_pass`). This repo mounts `crs-apache/httpd-vhosts.conf` and nginx `crs-nginx/realip.conf`. Plugin `ServeHTTP` already allows sidecar `< 300` and copies 3xx/4xx as a block — do not change it.
+
+Explore measured: nginx `return 200` in `location /` skips CRS (URI and POST-body probes returned 200). Apache image `/healthz` `RewriteRule` `[R=200]` still 403s those probes, but a 2-byte 200 + `Range: bytes=10240-` is still 416.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Inspect-only 200 after request phases on Apache and nginx compose in this repo
+- Drop unlabeled `dummy`; keep labeled whoami apps
+- Sidecar never 416 on `Range`; client-IP overlays unchanged
+
+**Non-Goals:**
+
+- Plugin Config / `serve.go` / in-process libmodsecurity
+- Pointing `BACKEND` at Traefik or the real app
+- Committing `Benchmark*` (throughput is measured for the delivery card only)
+
+## Decisions
+
+1. **Apache inspect-only = existing `/healthz` rewrite, not Lua/CGI.** `rewrite_module` is loaded; `mod_lua` / `mod_cgi` are on disk but not loaded. Live `/healthz`: benign POST 200, URI/POST SQLi 403. Alternative (Lua `DONE`) needs `LoadModule` we do not want.
+
+2. **Unset `Range` and `If-Range` on the Apache inspect-only vhost.** Tiny 200 bodies 416 without this; dummy whoami was the same class of failure. Alternative: CGI that ignores Range — extra module.
+
+3. **Nginx: loopback drain-200, never `return`.** Measured `return 200` allowed SQLi. Image has `nc`, not Python/`httpd`. Entrypoint.d starts a loopback listener that always writes HTTP 200 (ignore Range); `BACKEND=http://127.0.0.1:18081` (or the next free high port). Keep `zz-realip.conf`. Alternative: custom image — heavier.
+
+4. **Identity stays with Traefik + CRS remoteip/real_ip.** Do not set `X-Real-IP` in the drain or rewrite handler.
+
+## Risks / Trade-offs
+
+- [nginx drain dies] → sidecar 502 → plugin WAF failure / fail-open. Mitigation: simple `nc` loop, loopback only, compose healthcheck still hits `/` or `/healthz`.
+- [Apache rewrite 200 skips a future CRS phase] → Mitigation: Pester URI + POST-body probes are the gate; abort if they 200.
+- [Range unset hides a real Range from CRS] → CRS does not need Range for request rules; app still sees Range via `next`.
+
+## Migration Plan
+
+Operators who copied `BACKEND=http://dummy` from this repo’s compose drop dummy and take the overlay files. Rollback: restore previous compose + vhost. No plugin version bump required.
+
+## Open Questions
+
+None that change specs. Drain port 18081 is assumed; implement may pick another loopback high port.

--- a/openspec/changes/inspect-only-crs-sidecar/design.md
+++ b/openspec/changes/inspect-only-crs-sidecar/design.md
@@ -1,43 +1,47 @@
 ## Context
 
-See proposal.md Why. Stock `owasp/modsecurity-crs` 4.3.0 pins reverse-proxy to `BACKEND` (Apache `ProxyPass`, nginx `proxy_pass`). This repo mounts `crs-apache/httpd-vhosts.conf` and nginx `crs-nginx/realip.conf`. Plugin `ServeHTTP` already allows sidecar `< 300` and copies 3xx/4xx as a block — do not change it.
+See proposal.md Why. Stock `owasp/modsecurity-crs` 4.3.0 pins reverse-proxy to `BACKEND` (Apache `ProxyPass`, nginx `proxy_pass`). This repo mounts `crs-apache/httpd-vhosts.conf` (whoami hop) and `crs-apache/httpd-vhosts.drain.conf` (inspect-only). nginx whoami uses image `proxy_pass` to dummy; nginx drain adds `crs-nginx/drain-origin.conf`. Plugin `ServeHTTP` already allows sidecar `< 300` and copies 3xx/4xx as a block — do not change it.
 
-Explore measured: nginx `return 200` in `location /` skips CRS (URI and POST-body probes returned 200). Apache image `/healthz` `RewriteRule` `[R=200]` still 403s those probes, but a 2-byte 200 + `Range: bytes=10240-` is still 416.
+Explore measured: nginx `return 200` in CRS `location /` skips CRS (URI and POST-body probes returned 200). Apache image `/healthz` `RewriteRule` `[R=200]` still 403s those probes, but a 2-byte 200 + `Range: bytes=10240-` is still 416.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Inspect-only 200 after request phases on Apache and nginx compose in this repo
-- Drop unlabeled `dummy`; keep labeled whoami apps
-- Sidecar never 416 on `Range`; client-IP overlays unchanged
+- Inspect-only 200 after request phases on demo compose and drain test stacks
+- Keep unlabeled `dummy` on apache-whoami and nginx-whoami test stacks
+- Sidecar never 416 on `Range` on drain stacks; client-IP overlays unchanged
+- Benchmark allow-path GET and POST on all four stacks inside the integration suite
 
 **Non-Goals:**
 
 - Plugin Config / `serve.go` / in-process libmodsecurity
 - Pointing `BACKEND` at Traefik or the real app
-- Committing `Benchmark*` (throughput is measured for the delivery card only)
+- Committing Go `Benchmark*` tests (throughput is Pester + bombardier)
 
 ## Decisions
 
-1. **Apache inspect-only = existing `/healthz` rewrite, not Lua/CGI.** `rewrite_module` is loaded; `mod_lua` / `mod_cgi` are on disk but not loaded. Live `/healthz`: benign POST 200, URI/POST SQLi 403. Alternative (Lua `DONE`) needs `LoadModule` we do not want.
+1. **Apache inspect-only = existing `/healthz` rewrite, not Lua/CGI.** `rewrite_module` is loaded; `mod_lua` / `mod_cgi` are on disk but not loaded. Live `/healthz`: benign POST 200, URI/POST SQLi 403. Alternative (Lua `DONE`) needs `LoadModule` we do not want. Whoami Apache vhost stays stock ProxyPass.
 
 2. **Unset `Range` and `If-Range` on the Apache inspect-only vhost.** Tiny 200 bodies 416 without this; dummy whoami was the same class of failure. Alternative: CGI that ignores Range — extra module.
 
-3. **Nginx: loopback drain-200, never `return`.** Measured `return 200` allowed SQLi. Image has `nc`, not Python/`httpd`. Entrypoint.d starts a loopback listener that always writes HTTP 200 (ignore Range); `BACKEND=http://127.0.0.1:18081` (or the next free high port). Keep `zz-realip.conf`. Alternative: custom image — heavier.
+3. **Nginx drain origin = loopback `server` after `proxy_pass`, never `return` on CRS `location /`.** Measured `return 200` on `location /` allowed SQLi. A second listen on `127.0.0.1:18081` with `max_ranges 0` and `return 200` is dummy-equivalent (CRS already ran). Concurrent (unlike serial `nc`). Keep `zz-realip.conf`. Alternative: `nc` loop — serial, invalid for throughput compare.
 
-4. **Identity stays with Traefik + CRS remoteip/real_ip.** Do not set `X-Real-IP` in the drain or rewrite handler.
+4. **Four compose stacks, not drain-only tests.** Base whoami files plus drain overlays (`dummy` `profiles: [whoami-origin]`). `Test-Integration.ps1 -Stack` / `-AllStacks`. CI matrix of four. Pester skips dummy-absent / Range-not-416 on whoami stacks and skips dummy-present on drain.
+
+5. **Identity stays with Traefik + CRS remoteip/real_ip.** Do not set `X-Real-IP` in the drain or rewrite handler.
 
 ## Risks / Trade-offs
 
-- [nginx drain dies] → sidecar 502 → plugin WAF failure / fail-open. Mitigation: simple `nc` loop, loopback only, compose healthcheck still hits `/` or `/healthz`.
+- [nginx drain origin down] → sidecar 502 → plugin WAF failure / fail-open. Mitigation: in-process nginx `server` on loopback; compose healthcheck still hits public `:8080`.
 - [Apache rewrite 200 skips a future CRS phase] → Mitigation: Pester URI + POST-body probes are the gate; abort if they 200.
 - [Range unset hides a real Range from CRS] → CRS does not need Range for request rules; app still sees Range via `next`.
+- [Absolute RPS assertions flake] → Assert req/s > 0; print `BENCH stack=` lines for the card.
 
 ## Migration Plan
 
-Operators who copied `BACKEND=http://dummy` from this repo’s compose drop dummy and take the overlay files. Rollback: restore previous compose + vhost. No plugin version bump required.
+Operators who copied `BACKEND=http://dummy` from this repo’s **demo** compose drop dummy and take `httpd-vhosts.drain.conf`. Test whoami stacks stay on dummy. Rollback: restore previous compose + vhost. No plugin version bump required.
 
 ## Open Questions
 
-None that change specs. Drain port 18081 is assumed; implement may pick another loopback high port.
+None that change specs. Drain listen is `127.0.0.1:18081`.

--- a/openspec/changes/inspect-only-crs-sidecar/proposal.md
+++ b/openspec/changes/inspect-only-crs-sidecar/proposal.md
@@ -1,19 +1,20 @@
 ## Why
 
-The OWASP CRS sidecar still reverse-proxies every inspect to an unlabeled dummy whoami. That hop is not Traefik `next`, so dummy/whoami behavior (Range 416, large-body proxy errors) is copied as a WAF block, operators confuse dummy with the app, and every allow pays an extra origin round-trip.
+The OWASP CRS sidecar still reverse-proxies every inspect to an unlabeled dummy whoami. That hop is not Traefik `next`, so dummy/whoami behavior (Range 416, large-body proxy errors) is copied as a WAF block, operators confuse dummy with the app, and every allow pays an extra origin round-trip. Demo compose should be inspect-only. The test suite must still keep the dummy hop so whoami vs drain can be compared, including throughput.
 
 ## What Changes
 
-- Apache CRS overlay (`crs-apache/httpd-vhosts.conf`): stop `ProxyPass` / websocket `[P]` to `${BACKEND}`; after request phases answer HTTP 200 with the image’s `/healthz` rewrite pattern; unset `Range` / `If-Range` so a tiny 200 is not 416.
-- Nginx CRS overlay: do **not** use `return 200` (measured: URI and POST-body CRS probes become 200). Same-container loopback drain-200 plus `BACKEND` to that listener; keep `crs-nginx/realip.conf`.
-- Compose: delete unlabeled `dummy` on demo and test files. Keep labeled whoami apps. Plugin `ServeHTTP` unchanged.
-- README / integration usage: dummy-as-always-200 becomes shadow WAF (sidecar inspect + 200; `next` is the app).
+- Apache CRS drain overlay (`crs-apache/httpd-vhosts.drain.conf`): stop `ProxyPass` / websocket `[P]` to `${BACKEND}`; after request phases answer HTTP 200 with the image’s `/healthz` rewrite pattern; unset `Range` / `If-Range` so a tiny 200 is not 416. Whoami Apache vhost (`httpd-vhosts.conf`) stays ProxyPass for the whoami test stack.
+- Nginx CRS drain overlay: do **not** use `return 200` on the CRS-facing `location /` (measured: URI and POST-body CRS probes become 200). Loopback origin after `proxy_pass` (`crs-nginx/drain-origin.conf`, `BACKEND=http://127.0.0.1:18081`); keep `crs-nginx/realip.conf`.
+- Demo compose (`docker-compose.yml`, `docker-compose.local.yml`): drain Apache overlay, no dummy.
+- Test suite: four stacks — apache+whoami, nginx+whoami, apache+drain, nginx+drain. Pester benches all four. Plugin `ServeHTTP` unchanged.
+- README / integration usage: dummy is the whoami-origin test hop; drain/demo is shadow WAF (sidecar inspect + 200; `next` is the app).
 
 ## Capabilities
 
 ### New Capabilities
 
-- `core_crs_sidecar_inspect-only`: CRS Docker sidecar used by this repo’s compose answers HTTP 200 after ModSecurity request phases, without a dummy origin, while still blocking URI and POST-body CRS hits and not emitting sidecar 416 on `Range`.
+- `core_crs_sidecar_inspect-only`: CRS Docker sidecar used by this repo’s demo and drain stacks answers HTTP 200 after ModSecurity request phases, without a dummy origin, while still blocking URI and POST-body CRS hits and not emitting sidecar 416 on `Range`. Whoami test stacks keep dummy. The suite measures allow-path throughput on all four.
 
 ### Modified Capabilities
 
@@ -21,7 +22,8 @@ None. Plugin sidecar request/response specs stay; this is compose + CRS overlay,
 
 ## Impact
 
-- `crs-apache/httpd-vhosts.conf`, new files under `crs-nginx/`, `docker-compose.yml`, `docker-compose.local.yml`, `docker-compose.test.yml`, `docker-compose.test.nginx.yml`
-- `README.md` How it works; `knowledge/devdocs/build_testing_integration.md` dummy wording
+- `crs-apache/httpd-vhosts.conf` (whoami), `crs-apache/httpd-vhosts.drain.conf`, `crs-nginx/drain-origin.conf`
+- `docker-compose.yml`, `docker-compose.local.yml`, `docker-compose.test.yml`, `docker-compose.test.nginx.yml`, drain overlays, `Test-Integration.ps1`, `.github/workflows/integration-test.yml`
+- `README.md` How it works; `knowledge/devdocs/build_testing_integration.md`
 - Pester live CRS suite is the authority. Go unit tests mock the sidecar and will not catch a broken overlay.
-- No plugin Config key. No `pkg/modsecurity/serve.go` change.
+- No plugin Config key. No `pkg/modsecurity/serve.go` change. No committed Go `Benchmark*` tests; throughput lives in Pester via bombardier.

--- a/openspec/changes/inspect-only-crs-sidecar/proposal.md
+++ b/openspec/changes/inspect-only-crs-sidecar/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The OWASP CRS sidecar still reverse-proxies every inspect to an unlabeled dummy whoami. That hop is not Traefik `next`, so dummy/whoami behavior (Range 416, large-body proxy errors) is copied as a WAF block, operators confuse dummy with the app, and every allow pays an extra origin round-trip.
+
+## What Changes
+
+- Apache CRS overlay (`crs-apache/httpd-vhosts.conf`): stop `ProxyPass` / websocket `[P]` to `${BACKEND}`; after request phases answer HTTP 200 with the image’s `/healthz` rewrite pattern; unset `Range` / `If-Range` so a tiny 200 is not 416.
+- Nginx CRS overlay: do **not** use `return 200` (measured: URI and POST-body CRS probes become 200). Same-container loopback drain-200 plus `BACKEND` to that listener; keep `crs-nginx/realip.conf`.
+- Compose: delete unlabeled `dummy` on demo and test files. Keep labeled whoami apps. Plugin `ServeHTTP` unchanged.
+- README / integration usage: dummy-as-always-200 becomes shadow WAF (sidecar inspect + 200; `next` is the app).
+
+## Capabilities
+
+### New Capabilities
+
+- `core_crs_sidecar_inspect-only`: CRS Docker sidecar used by this repo’s compose answers HTTP 200 after ModSecurity request phases, without a dummy origin, while still blocking URI and POST-body CRS hits and not emitting sidecar 416 on `Range`.
+
+### Modified Capabilities
+
+None. Plugin sidecar request/response specs stay; this is compose + CRS overlay, not `ServeHTTP`.
+
+## Impact
+
+- `crs-apache/httpd-vhosts.conf`, new files under `crs-nginx/`, `docker-compose.yml`, `docker-compose.local.yml`, `docker-compose.test.yml`, `docker-compose.test.nginx.yml`
+- `README.md` How it works; `knowledge/devdocs/build_testing_integration.md` dummy wording
+- Pester live CRS suite is the authority. Go unit tests mock the sidecar and will not catch a broken overlay.
+- No plugin Config key. No `pkg/modsecurity/serve.go` change.

--- a/openspec/changes/inspect-only-crs-sidecar/specs/core_crs_sidecar_inspect-only/spec.md
+++ b/openspec/changes/inspect-only-crs-sidecar/specs/core_crs_sidecar_inspect-only/spec.md
@@ -1,12 +1,12 @@
 ## Purpose
 
-Defines how this repo’s OWASP CRS Docker sidecar inspects a request copy and answers HTTP 200 without a dummy origin, while still applying CRS request rules and without turning `Range` into a sidecar 4xx that the plugin copies as a block.
+Defines how this repo’s OWASP CRS Docker sidecar inspects a request copy and answers HTTP 200. Demo compose and drain test stacks do that without a dummy origin. Whoami test stacks keep the stock dummy hop so both origins stay measurable. CRS request rules still apply. Drain origins MUST NOT turn `Range` into a sidecar 4xx that the plugin copies as a block.
 
 ## ADDED Requirements
 
 ### Requirement: Sidecar allow is HTTP 200 without a dummy origin
 
-After ModSecurity request phases, the CRS sidecar used by this repo’s compose files SHALL respond HTTP 200 to a benign GET and to a benign POST with a small body. Compose SHALL NOT run an unlabeled `dummy` whoami as that sidecar’s origin. Traefik `next` remains the application. The plugin SHALL treat that sidecar 200 as allow (existing `< 300` rule).
+After ModSecurity request phases, the CRS sidecar used by this repo’s demo compose and drain test stacks SHALL respond HTTP 200 to a benign GET and to a benign POST with a small body. Those compose files SHALL NOT run an unlabeled `dummy` whoami as that sidecar’s origin. Traefik `next` remains the application. The plugin SHALL treat that sidecar 200 as allow (existing `< 300` rule).
 
 #### Scenario: Benign GET through Traefik
 
@@ -20,14 +20,23 @@ After ModSecurity request phases, the CRS sidecar used by this repo’s compose 
 - **THEN** the sidecar SHALL respond HTTP 200 (not 405)
 - **AND** the application SHALL receive that body via `next`
 
-#### Scenario: No dummy service
+#### Scenario: No dummy service on drain and demo stacks
 
-- **WHEN** the demo or test compose stack is up
-- **THEN** `docker compose ps` SHALL NOT list a `dummy` service
+- **WHEN** demo compose, `apache-drain`, or `nginx-drain` is up
+- **THEN** `docker compose ps` SHALL NOT list a running `dummy` service
+
+### Requirement: Whoami-origin stacks keep the dummy hop
+
+The integration suite SHALL still ship Apache+whoami and nginx+whoami stacks that run unlabeled `dummy` and set `BACKEND=http://dummy` (Apache `ProxyPass` / nginx `proxy_pass`). Those stacks exist to compare the extra hop against drain.
+
+#### Scenario: Dummy present on whoami stacks
+
+- **WHEN** `apache-whoami` or `nginx-whoami` is up
+- **THEN** a `dummy` container SHALL be running
 
 ### Requirement: CRS still blocks URI and POST-body probes
 
-The inspect-only 200 handler SHALL NOT skip ModSecurity request-header or request-body inspection. A classic CRS probe in the URI or query SHALL produce a sidecar deny (typically 403). A classic CRS probe in the POST body SHALL produce a sidecar deny. A nginx `return` that answers 200 without running those phases SHALL NOT be used.
+The inspect-only 200 handler SHALL NOT skip ModSecurity request-header or request-body inspection. A classic CRS probe in the URI or query SHALL produce a sidecar deny (typically 403). A classic CRS probe in the POST body SHALL produce a sidecar deny. A nginx `return` that answers 200 on the CRS-facing `location /` without running those phases SHALL NOT be used. A `return 200` on a loopback origin after `proxy_pass` is allowed (CRS already ran).
 
 #### Scenario: URI probe is denied
 
@@ -41,17 +50,27 @@ The inspect-only 200 handler SHALL NOT skip ModSecurity request-header or reques
 - **THEN** the sidecar SHALL respond 403 (or the configured deny status below 500)
 - **AND** Traefik `next` SHALL NOT be called
 
-### Requirement: Range does not become a sidecar security block
+### Requirement: Range does not become a sidecar security block on drain origins
 
-A client `Range` that would be unsatisfiable on a small sidecar body (including `Range: bytes=10240-` on a tiny inspect-only 200) SHALL NOT produce a sidecar 4xx. The sidecar SHALL respond HTTP 200 for that inspect. Traefik `next` may still return 206 or 200 from the application. Client IP for WAF audit SHALL remain Traefik `ClientHost` via the existing `X-Real-IP` overlays (`RemoteIPHeader` / nginx `real_ip`). The plugin SHALL NOT reconstruct client IP.
+A client `Range` that would be unsatisfiable on a small sidecar body (including `Range: bytes=10240-` on a tiny inspect-only 200) SHALL NOT produce a sidecar 4xx on drain stacks. The sidecar SHALL respond HTTP 200 for that inspect. Traefik `next` may still return 206 or 200 from the application. Whoami-origin stacks MAY still copy dummy 416. Client IP for WAF audit SHALL remain Traefik `ClientHost` via the existing `X-Real-IP` overlays (`RemoteIPHeader` / nginx `real_ip`). The plugin SHALL NOT reconstruct client IP.
 
-#### Scenario: Large Range on a small GET
+#### Scenario: Large Range on a small GET (drain)
 
-- **WHEN** a client GET to a WAF-protected route includes `Range: bytes=10240-`
+- **WHEN** a client GET to a WAF-protected route on a drain stack includes `Range: bytes=10240-`
 - **THEN** the sidecar SHALL respond HTTP 200
 - **AND** the client SHALL NOT receive a sidecar 416 copied as a WAF block
 
 #### Scenario: Deny audit still has Traefik ClientHost
 
-- **WHEN** CRS denies a request on the inspect-only sidecar
+- **WHEN** CRS denies a request on any of the four stacks
 - **THEN** the WAF JSON audit `REMOTE_ADDR` SHALL equal Traefik access-log `ClientHost` for that request
+
+### Requirement: Four-stack suite measures allow-path throughput
+
+The integration suite SHALL include all four stacks: `apache-whoami`, `nginx-whoami`, `apache-drain`, `nginx-drain`. Each stack run SHALL measure allow-path GET and POST throughput on `/protected` (bombardier `-c 50 -d 15s` or equivalent in Pester). The assertion is that req/s is greater than zero; absolute RPS is recorded for the delivery card, not as a flake-prone floor.
+
+#### Scenario: All four stacks are in CI
+
+- **WHEN** the integration-test workflow runs
+- **THEN** it SHALL start each of the four stacks
+- **AND** it SHALL print a `BENCH stack=... method=... rps=...` line for GET and POST when bombardier is installed

--- a/openspec/changes/inspect-only-crs-sidecar/specs/core_crs_sidecar_inspect-only/spec.md
+++ b/openspec/changes/inspect-only-crs-sidecar/specs/core_crs_sidecar_inspect-only/spec.md
@@ -1,0 +1,57 @@
+## Purpose
+
+Defines how this repo’s OWASP CRS Docker sidecar inspects a request copy and answers HTTP 200 without a dummy origin, while still applying CRS request rules and without turning `Range` into a sidecar 4xx that the plugin copies as a block.
+
+## ADDED Requirements
+
+### Requirement: Sidecar allow is HTTP 200 without a dummy origin
+
+After ModSecurity request phases, the CRS sidecar used by this repo’s compose files SHALL respond HTTP 200 to a benign GET and to a benign POST with a small body. Compose SHALL NOT run an unlabeled `dummy` whoami as that sidecar’s origin. Traefik `next` remains the application. The plugin SHALL treat that sidecar 200 as allow (existing `< 300` rule).
+
+#### Scenario: Benign GET through Traefik
+
+- **WHEN** a client GET with no CRS probe reaches a WAF-protected route
+- **THEN** the sidecar SHALL respond HTTP 200
+- **AND** the application body and status SHALL be unchanged from Traefik `next`
+
+#### Scenario: Benign POST through Traefik
+
+- **WHEN** a client POST with a small non-attack body reaches a WAF-protected route
+- **THEN** the sidecar SHALL respond HTTP 200 (not 405)
+- **AND** the application SHALL receive that body via `next`
+
+#### Scenario: No dummy service
+
+- **WHEN** the demo or test compose stack is up
+- **THEN** `docker compose ps` SHALL NOT list a `dummy` service
+
+### Requirement: CRS still blocks URI and POST-body probes
+
+The inspect-only 200 handler SHALL NOT skip ModSecurity request-header or request-body inspection. A classic CRS probe in the URI or query SHALL produce a sidecar deny (typically 403). A classic CRS probe in the POST body SHALL produce a sidecar deny. A nginx `return` that answers 200 without running those phases SHALL NOT be used.
+
+#### Scenario: URI probe is denied
+
+- **WHEN** a client GET includes a CRS SQL-injection query on a WAF-protected route
+- **THEN** the sidecar SHALL respond 403 (or the configured deny status below 500)
+- **AND** Traefik `next` SHALL NOT be called
+
+#### Scenario: POST-body probe is denied
+
+- **WHEN** a client POST body contains a CRS SQL-injection probe and the URI is otherwise benign
+- **THEN** the sidecar SHALL respond 403 (or the configured deny status below 500)
+- **AND** Traefik `next` SHALL NOT be called
+
+### Requirement: Range does not become a sidecar security block
+
+A client `Range` that would be unsatisfiable on a small sidecar body (including `Range: bytes=10240-` on a tiny inspect-only 200) SHALL NOT produce a sidecar 4xx. The sidecar SHALL respond HTTP 200 for that inspect. Traefik `next` may still return 206 or 200 from the application. Client IP for WAF audit SHALL remain Traefik `ClientHost` via the existing `X-Real-IP` overlays (`RemoteIPHeader` / nginx `real_ip`). The plugin SHALL NOT reconstruct client IP.
+
+#### Scenario: Large Range on a small GET
+
+- **WHEN** a client GET to a WAF-protected route includes `Range: bytes=10240-`
+- **THEN** the sidecar SHALL respond HTTP 200
+- **AND** the client SHALL NOT receive a sidecar 416 copied as a WAF block
+
+#### Scenario: Deny audit still has Traefik ClientHost
+
+- **WHEN** CRS denies a request on the inspect-only sidecar
+- **THEN** the WAF JSON audit `REMOTE_ADDR` SHALL equal Traefik access-log `ClientHost` for that request

--- a/openspec/changes/inspect-only-crs-sidecar/tasks.md
+++ b/openspec/changes/inspect-only-crs-sidecar/tasks.md
@@ -1,0 +1,28 @@
+## 1. Write failing test
+
+- [ ] 1.1 In `scripts/integration-tests.Tests.ps1`, add an `It` that GET `/protected` with `Range: bytes=10240-` via `Invoke-SafeWebRequest` and asserts the client status is not 416 (use `-Because`). Confirm it fails on current Apache compose (today is 416).
+- [ ] 1.2 Add an `It` that POST `/protected` with a CRS SQL-injection body (`Content-Type: application/x-www-form-urlencoded`) via `Invoke-SafeWebRequest` and asserts status ≥ 400. Confirm it passes today (control — must stay failing-if-broken after overlays).
+- [ ] 1.3 Add an `It` that `dummy` is not a running compose service (assert via existing Docker helpers in `scripts/TestHelpers.ps1`, or add a small helper there if inspect is non-trivial). Confirm it fails while `dummy` still exists.
+
+## 2. Apache inspect-only overlay
+
+- [ ] 2.1 Edit `crs-apache/httpd-vhosts.conf`: remove `ProxyPass` / `ProxyPassReverse` / unused proxy knobs and websocket `[P]` to `${BACKEND_WS}`. Keep `RemoteIPHeader X-Real-IP`, `RemoteIPInternalProxy`, Unique-ID / X-Forwarded-Proto request headers.
+- [ ] 2.2 Add the image `/healthz` rewrite pattern on `/` (`RewriteRule` `[R=200]` + `ErrorDocument 200`) and `RequestHeader unset Range` / `If-Range`.
+- [ ] 2.3 Drop unlabeled `dummy` and `BACKEND=http://dummy` from `docker-compose.yml`, `docker-compose.local.yml`, and `docker-compose.test.yml`. Keep labeled whoami apps.
+
+## 3. Nginx drain-200 overlay
+
+- [ ] 3.1 Add `crs-nginx/` loopback drain (entrypoint.d script using image `nc`, listen `127.0.0.1:18081` or the next free high port) that always writes HTTP 200 and ignores `Range`.
+- [ ] 3.2 Point `docker-compose.test.nginx.yml` `BACKEND` at that loopback URL; mount the script into `/docker-entrypoint.d/`. Keep `crs-nginx/realip.conf`. Do not use nginx `return 200` on `location /`.
+- [ ] 3.3 Drop unlabeled `dummy` from `docker-compose.test.nginx.yml`.
+
+## 4. Docs
+
+- [ ] 4.1 Rewrite README How-it-works dummy/always-200 as shadow WAF (sidecar inspect + 200; Traefik `next` is the app).
+- [ ] 4.2 Update `knowledge/devdocs/build_testing_integration.md` so dummy is not named as the CRS origin.
+
+## 5. Prove and measure
+
+- [ ] 5.1 Run `./Test-Integration.ps1` (Apache compose) and `./Test-Integration.ps1 -ComposeFile ./docker-compose.test.nginx.yml`. Tasks 1.1–1.3 SHALL pass. Use helpers from `scripts/TestHelpers.ps1` only (see `knowledge/devdocs/build_testing_integration.md`).
+- [ ] 5.2 Curl `waf:8080` GET allow, POST allow, URI block, POST-body block, Range not 416. Record on the delivery card.
+- [ ] 5.3 Bombardier after, same flags as explore (`-c 50 -d 15s`, `http://localhost:8000/protected` GET and POST). Put before (GET 5077 req/s, POST 1098 req/s), after, and delta on the delivery card. Do not add `Benchmark*` to the tree.

--- a/openspec/changes/inspect-only-crs-sidecar/tasks.md
+++ b/openspec/changes/inspect-only-crs-sidecar/tasks.md
@@ -1,28 +1,29 @@
 ## 1. Write failing test
 
-- [ ] 1.1 In `scripts/integration-tests.Tests.ps1`, add an `It` that GET `/protected` with `Range: bytes=10240-` via `Invoke-SafeWebRequest` and asserts the client status is not 416 (use `-Because`). Confirm it fails on current Apache compose (today is 416).
-- [ ] 1.2 Add an `It` that POST `/protected` with a CRS SQL-injection body (`Content-Type: application/x-www-form-urlencoded`) via `Invoke-SafeWebRequest` and asserts status ≥ 400. Confirm it passes today (control — must stay failing-if-broken after overlays).
-- [ ] 1.3 Add an `It` that `dummy` is not a running compose service (assert via existing Docker helpers in `scripts/TestHelpers.ps1`, or add a small helper there if inspect is non-trivial). Confirm it fails while `dummy` still exists.
+- [x] 1.1 In `scripts/integration-tests.Tests.ps1`, add an `It` that GET `/protected` with `Range: bytes=10240-` via `Invoke-SafeWebRequest` and asserts the client status is not 416 (use `-Because`). Skip on whoami-origin stacks.
+- [x] 1.2 Add an `It` that POST `/protected` with a CRS SQL-injection body (`Content-Type: application/x-www-form-urlencoded`) via `Invoke-SafeWebRequest` and asserts status ≥ 400. Confirm it passes on all four stacks.
+- [x] 1.3 Add Its that `dummy` is absent on drain stacks and present on whoami stacks (`Get-DummyContainerName`).
 
 ## 2. Apache inspect-only overlay
 
-- [ ] 2.1 Edit `crs-apache/httpd-vhosts.conf`: remove `ProxyPass` / `ProxyPassReverse` / unused proxy knobs and websocket `[P]` to `${BACKEND_WS}`. Keep `RemoteIPHeader X-Real-IP`, `RemoteIPInternalProxy`, Unique-ID / X-Forwarded-Proto request headers.
-- [ ] 2.2 Add the image `/healthz` rewrite pattern on `/` (`RewriteRule` `[R=200]` + `ErrorDocument 200`) and `RequestHeader unset Range` / `If-Range`.
-- [ ] 2.3 Drop unlabeled `dummy` and `BACKEND=http://dummy` from `docker-compose.yml`, `docker-compose.local.yml`, and `docker-compose.test.yml`. Keep labeled whoami apps.
+- [x] 2.1 Keep whoami `crs-apache/httpd-vhosts.conf` as ProxyPass (restore from main). Add `crs-apache/httpd-vhosts.drain.conf`: no `ProxyPass` / websocket `[P]`; keep `RemoteIPHeader X-Real-IP`.
+- [x] 2.2 Drain vhost: image `/healthz` rewrite on `/` (`RewriteRule` `[R=200]` + `ErrorDocument 200`) and `RequestHeader unset Range` / `If-Range` `early`.
+- [x] 2.3 Demo `docker-compose.yml` / `docker-compose.local.yml`: drop dummy, mount drain vhost. `docker-compose.test.yml`: keep dummy + `BACKEND=http://dummy`. Add `docker-compose.test.apache-drain.yml` overlay.
 
-## 3. Nginx drain-200 overlay
+## 3. Nginx drain overlay
 
-- [ ] 3.1 Add `crs-nginx/` loopback drain (entrypoint.d script using image `nc`, listen `127.0.0.1:18081` or the next free high port) that always writes HTTP 200 and ignores `Range`.
-- [ ] 3.2 Point `docker-compose.test.nginx.yml` `BACKEND` at that loopback URL; mount the script into `/docker-entrypoint.d/`. Keep `crs-nginx/realip.conf`. Do not use nginx `return 200` on `location /`.
-- [ ] 3.3 Drop unlabeled `dummy` from `docker-compose.test.nginx.yml`.
+- [x] 3.1 Add `crs-nginx/drain-origin.conf` loopback `server` on `127.0.0.1:18081` (`max_ranges 0`, `return 200`). Do not use `return` on CRS `location /`.
+- [x] 3.2 Add `docker-compose.test.nginx-drain.yml`: `BACKEND=http://127.0.0.1:18081`, mount drain-origin; keep `crs-nginx/realip.conf` on the base file.
+- [x] 3.3 Keep unlabeled `dummy` on `docker-compose.test.nginx.yml`. Drain overlay sets dummy `profiles: [whoami-origin]`.
 
-## 4. Docs
+## 4. Docs and runner
 
-- [ ] 4.1 Rewrite README How-it-works dummy/always-200 as shadow WAF (sidecar inspect + 200; Traefik `next` is the app).
-- [ ] 4.2 Update `knowledge/devdocs/build_testing_integration.md` so dummy is not named as the CRS origin.
+- [x] 4.1 Rewrite README How-it-works dummy/always-200 as shadow WAF for demo/drain; whoami test stacks still use dummy.
+- [x] 4.2 Update `knowledge/devdocs/build_testing_integration.md` for four stacks, skips, and bombardier benches.
+- [x] 4.3 `Test-Integration.ps1 -Stack` / `-AllStacks`. CI matrix of four stacks; install bombardier.
 
 ## 5. Prove and measure
 
-- [ ] 5.1 Run `./Test-Integration.ps1` (Apache compose) and `./Test-Integration.ps1 -ComposeFile ./docker-compose.test.nginx.yml`. Tasks 1.1–1.3 SHALL pass. Use helpers from `scripts/TestHelpers.ps1` only (see `knowledge/devdocs/build_testing_integration.md`).
-- [ ] 5.2 Curl `waf:8080` GET allow, POST allow, URI block, POST-body block, Range not 416. Record on the delivery card.
-- [ ] 5.3 Bombardier after, same flags as explore (`-c 50 -d 15s`, `http://localhost:8000/protected` GET and POST). Put before (GET 5077 req/s, POST 1098 req/s), after, and delta on the delivery card. Do not add `Benchmark*` to the tree.
+- [x] 5.1 Run `./Test-Integration.ps1 -Stack apache-whoami`, `nginx-whoami`, `apache-drain`, `nginx-drain` (or `-AllStacks`). Tasks 1.1–1.3 SHALL pass on the stacks they apply to.
+- [x] 5.2 Curl `waf:8080` GET allow, POST allow, URI block, POST-body block; Range not 416 on drain only. Record on the delivery card.
+- [x] 5.3 Bombardier on all four stacks, same flags as explore (`-c 50 -d 15s`, `http://localhost:8000/protected` GET and POST). Put before (Apache whoami GET 5077 req/s, POST 1098 req/s), after for all four, and delta on the delivery card. Pin upstream [acouvreur#2](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2). Do not add Go `Benchmark*` to the tree.

--- a/openspec/specs/domains.md
+++ b/openspec/specs/domains.md
@@ -4,6 +4,7 @@ Hand-kept permission list of root + domain. Add the domain bullet in the same ed
 
 ## core
 - plugin
+- crs
 
 ## build
 - ci

--- a/scripts/TestHelpers.ps1
+++ b/scripts/TestHelpers.ps1
@@ -25,6 +25,116 @@ function Get-WafContainerName {
     return $name
 }
 
+function Get-DummyContainerName {
+    # Unlabeled CRS origin (traefik/whoami). Present on *-whoami stacks; absent on *-drain.
+    docker ps --format "{{.Names}}" | Where-Object { $_ -like "*-dummy-1" } | Select-Object -First 1
+}
+
+function Get-IntegrationStackComposeFiles {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('apache-whoami', 'nginx-whoami', 'apache-drain', 'nginx-drain')]
+        [string]$Stack
+    )
+    switch ($Stack) {
+        'apache-whoami' { @('./docker-compose.test.yml') }
+        'nginx-whoami' { @('./docker-compose.test.nginx.yml') }
+        'apache-drain' { @('./docker-compose.test.yml', './docker-compose.test.apache-drain.yml') }
+        'nginx-drain' { @('./docker-compose.test.nginx.yml', './docker-compose.test.nginx-drain.yml') }
+    }
+}
+
+function Get-IntegrationOriginKind {
+    $stack = $env:INTEGRATION_STACK
+    if ($stack -like '*-drain') { return 'drain' }
+    if ($stack -like '*-whoami') { return 'whoami' }
+    if (Get-DummyContainerName) { return 'whoami' }
+    return 'drain'
+}
+
+function Test-IsDrainOrigin {
+    return (Get-IntegrationOriginKind) -eq 'drain'
+}
+
+function Test-IsWhoamiOrigin {
+    return (Get-IntegrationOriginKind) -eq 'whoami'
+}
+
+function Get-BombardierCommand {
+    $cmd = Get-Command bombardier -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    $candidates = @()
+    if ($env:GOPATH) {
+        $candidates += (Join-Path $env:GOPATH 'bin/bombardier.exe')
+        $candidates += (Join-Path $env:GOPATH 'bin/bombardier')
+    }
+    $goPath = $null
+    try { $goPath = (& go env GOPATH 2>$null | Select-Object -First 1) } catch { }
+    if ($goPath) {
+        $candidates += (Join-Path $goPath 'bin/bombardier.exe')
+        $candidates += (Join-Path $goPath 'bin/bombardier')
+    }
+    foreach ($p in $candidates) {
+        if ($p -and (Test-Path -LiteralPath $p)) { return $p }
+    }
+    return $null
+}
+
+function Invoke-AllowPathBombardier {
+    param(
+        [string]$Url = 'http://localhost:8000/protected',
+        [ValidateSet('GET', 'POST')]
+        [string]$Method = 'GET',
+        [string]$Body = 'name=john&email=john@example.com',
+        [int]$Connections = 50,
+        [string]$Duration = '15s'
+    )
+    $bin = Get-BombardierCommand
+    if (-not $bin) { return $null }
+
+    $argList = @('-c', "$Connections", '-d', $Duration, '-m', $Method, '--http1')
+    if ($Method -eq 'POST') {
+        $argList += @('-b', $Body, '-H', 'Content-Type: application/x-www-form-urlencoded')
+    }
+    $argList += $Url
+
+    $output = & $bin @argList 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        throw "bombardier exited $LASTEXITCODE`n$output"
+    }
+
+    $reqs = $null
+    $latencyMs = $null
+    $xx2 = $null
+    $xx5 = $null
+    if ($output -match 'Reqs/sec\s+([\d.]+)') { $reqs = [double]$Matches[1] }
+    if ($output -match 'Latency\s+([\d.]+)(us|ms|s)') {
+        $n = [double]$Matches[1]
+        switch ($Matches[2]) {
+            'us' { $latencyMs = $n / 1000.0 }
+            'ms' { $latencyMs = $n }
+            's' { $latencyMs = $n * 1000.0 }
+        }
+    }
+    if ($output -match '2xx\s*-\s*(\d+)') { $xx2 = [int]$Matches[1] }
+    if ($output -match '5xx\s*-\s*(\d+)') { $xx5 = [int]$Matches[1] }
+
+    $stack = $env:INTEGRATION_STACK
+    if (-not $stack) { $stack = 'unknown' }
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    $lat = if ($null -ne $latencyMs) { $latencyMs.ToString('0.00', $inv) } else { 'n/a' }
+    $rps = if ($null -ne $reqs) { $reqs.ToString('0.00', $inv) } else { 'n/a' }
+    Write-Host "BENCH stack=$stack method=$Method rps=$rps latency_ms=$lat xx2=$xx2 xx5=$xx5" -ForegroundColor Magenta
+
+    return [pscustomobject]@{
+        Output     = $output
+        ReqsPerSec = $reqs
+        LatencyMs  = $latencyMs
+        Status2xx  = $xx2
+        Status5xx  = $xx5
+    }
+}
+
 function Wait-ForWafHealthy {
     param(
         [Parameter(Mandatory)]

--- a/scripts/integration-tests.Tests.ps1
+++ b/scripts/integration-tests.Tests.ps1
@@ -49,6 +49,22 @@ Describe "ModSecurity Plugin Basic Functionality" {
             $response.StatusCode | Should -Be 200
             $response.Content | Should -Match "Hostname"
         }
+
+        It "Should not run an unlabeled dummy CRS origin" {
+            if (-not (Test-IsDrainOrigin)) {
+                Set-ItResult -Skipped -Because "whoami-origin stacks keep dummy as the CRS BACKEND"
+                return
+            }
+            Get-DummyContainerName | Should -BeNullOrEmpty -Because "Drain overlay must not start dummy; only labeled whoami apps remain"
+        }
+
+        It "Should run an unlabeled dummy CRS origin" {
+            if (-not (Test-IsWhoamiOrigin)) {
+                Set-ItResult -Skipped -Because "drain stacks do not run dummy"
+                return
+            }
+            Get-DummyContainerName | Should -Not -BeNullOrEmpty -Because "whoami-origin stacks proxy CRS BACKEND to dummy"
+        }
     }
 }
 
@@ -125,6 +141,20 @@ Describe "WAF Protection Tests" {
         It "Should allow POST requests with normal data" {
             $response = Invoke-SafeWebRequest -Uri "$BaseUrl/protected" -Method POST -Body "name=john&email=john@example.com"
             $response.StatusCode | Should -Be 200
+        }
+
+        It "Should not copy a sidecar 416 for Range bytes=10240- on a small GET" {
+            if (-not (Test-IsDrainOrigin)) {
+                Set-ItResult -Skipped -Because "whoami dummy origin is expected to 416 on an unsatisfiable Range"
+                return
+            }
+            $response = Invoke-SafeWebRequest -Uri "$BaseUrl/protected" -Headers @{ Range = "bytes=10240-" }
+            $response.StatusCode | Should -Not -Be 416 -Because "Inspect-only sidecar must not 416 on Range; plugin copies sidecar 4xx as a block"
+        }
+
+        It "Should block a CRS SQL-injection probe in the POST body" {
+            $response = Invoke-SafeWebRequest -Uri "$BaseUrl/protected" -Method POST -Headers @{ "Content-Type" = "application/x-www-form-urlencoded" } -Body "id=1 OR 1=1"
+            $response.StatusCode | Should -BeGreaterOrEqual 400 -Because "CRS request-body rules must still run after inspect-only 200"
         }
         
         It "Should allow requests with normal query parameters" {
@@ -698,6 +728,30 @@ Describe "Error Handling and Edge Cases" {
             $encodedUrl = "$BaseUrl/protected?name=" + [System.Web.HttpUtility]::UrlEncode("John & Jane")
             $response = Invoke-SafeWebRequest -Uri $encodedUrl
             $response.StatusCode | Should -Be 200
+        }
+    }
+}
+
+Describe "Allow-path throughput" {
+    Context "Bombardier on /protected" {
+        It "Should measure GET allow-path req/s" {
+            if (-not (Get-BombardierCommand)) {
+                Set-ItResult -Skipped -Because "bombardier not on PATH (CI installs it; locally: go install github.com/codesenberg/bombardier@latest)"
+                return
+            }
+            $result = Invoke-AllowPathBombardier -Method GET
+            $result | Should -Not -BeNullOrEmpty
+            $result.ReqsPerSec | Should -BeGreaterThan 0 -Because "allow-path GET must complete at least one request"
+        }
+
+        It "Should measure POST allow-path req/s" {
+            if (-not (Get-BombardierCommand)) {
+                Set-ItResult -Skipped -Because "bombardier not on PATH (CI installs it; locally: go install github.com/codesenberg/bombardier@latest)"
+                return
+            }
+            $result = Invoke-AllowPathBombardier -Method POST
+            $result | Should -Not -BeNullOrEmpty
+            $result.ReqsPerSec | Should -BeGreaterThan 0 -Because "allow-path POST must complete at least one request"
         }
     }
 }


### PR DESCRIPTION
Developer review: in progress — 2026-09-03T04:40:10Z

## What this changes
**Operators.** Demo compose (`docker-compose.yml` / `docker-compose.local.yml`) mounts `crs-apache/httpd-vhosts.drain.conf` and no longer runs unlabeled `dummy`. CRS inspects a copy and answers 200; Traefik `next` is the app.

**Admin users.** None.

**Developers.** Four named test stacks remain: `apache-whoami`, `nginx-whoami`, `apache-drain`, `nginx-drain`. `./Test-Integration.ps1 -Stack` / `-AllStacks` and CI matrix cover all four. Pester prints `BENCH stack=` bombardier lines. Plugin `ServeHTTP` is unchanged.

**End users.** On drain/demo, `Range: bytes=10240-` is no longer copied as a sidecar 416 WAF block. Whoami test stacks still can 416 (dummy origin).

## Motivation
On main, every CRS inspect still `ProxyPass` / `proxy_pass` to unlabeled dummy whoami. That hop is not the real app, so dummy/whoami behavior (Range 416) is copied as a security block, operators confuse dummy with Traefik's backend, and every allow pays an extra origin round-trip. That extra hop is one slice of the long-standing WAF-path cost tracked upstream in [acouvreur/traefik-modsecurity-plugin#2](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2) (bombardier: no-WAF ~14430 req/s vs WAF ~748 req/s, ~20x). Without this PR those false blocks stay, and we cannot compare dummy vs inspect-only on the same suite.

## Merge readiness
Implement landed four stacks + benches; CI on this head not seen yet. 2 items remain.

Priority: P2 — real operator pain from dummy/whoami (false 4xx blocks, extra hop), with a workaround of keeping dummy on whoami test stacks
Reviewed head: adb3e2ec373d3adb0484c87351b5bd7ad653a8bf
Owner decision: None.

## Review scores
| Measure | Result | What it means |
| --- | --- | --- |
| Overall readiness | 1/6 | Pushed apply; CI on this head not seen |
| CI proof | 1/6 | not seen on adb3e2e |
| Local tests proof | N/A | prHost github — CI proof covers remote |
| Review resolution | 6/6 | OPEN PR 31, no review comments |

## Verification
| Check | Result | Evidence |
| --- | --- | --- |
| Branch | 2026-09-03-remove-2nd-hop pushed | `git` |
| OpenSpec | inspect-only-crs-sidecar | `openspec/changes/inspect-only-crs-sidecar/` |
| Pull request | https://github.com/david-garcia-garcia/traefik-modsecurity/pull/31 | GitHub |
| CI | not seen | not measured on this head yet |
| Local tests | passed | `./Test-Integration.ps1 -AllStacks` — all four stacks 0 failed |
| PR comments | no comments | no comments.md items |
| Security | None. | no `codereview.md` yet |
| Performance | See Agent review details — pinned to [acouvreur#2](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2) | bombardier `-c 50 -d 15s` `/protected` |

## Specs
- [core_crs_sidecar_inspect-only](https://github.com/david-garcia-garcia/traefik-modsecurity/blob/2026-09-03-remove-2nd-hop/openspec/changes/inspect-only-crs-sidecar/proposal.md) — added

## Follow-up issues
- [ ] [note] [large] README `BenchmarkProtectedEndpoint` → no `Benchmark*` in this tree — README documents an integration bench that is not found. Not this ticket.

## How this fits together
Inspect-only CRS overlay is on branch `2026-09-03-remove-2nd-hop` as PR 31. Demo is drain-only; tests keep whoami + drain and bench all four. Throughput is the same class of measurement as [acouvreur#2](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2) (bombardier on WAF vs non-WAF). This PR does not remove the WAF hop; it removes the dummy origin after CRS.

## Decision needed
None.

## Before merge
- [ ] [P3] Wait for CI on the four-stack matrix (bombardier installed in the workflow)
- [x] Keep apache+whoami, nginx+whoami, apache+drain, nginx+drain in the suite and bench all four
- [x] Overlay CRS inspect-only 200 on demo + drain stacks (nginx: loopback origin, not `return` on CRS `location /`)
- [x] Prove live CRS gates: GET+POST allow, URI block, POST-body block, Range not sidecar 416 on drain, dummy present only on whoami stacks

## Findings
None.

## Agent review details

### Security
None.

### Performance
Upstream pin: [Increase plugin performance (#2)](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2) — bombardier, WAF path ~20x slower than no-WAF (748 vs 14430 req/s at `-c 125 -d 10s`). This ticket measures the **dummy origin hop inside the WAF path**, not WAF-off.

Before (explore, Apache whoami, `-c 50 -d 15s` `/protected`): GET 5077 req/s / 9.84 ms (76072 2xx / 125 5xx); POST 1098 req/s / 45.47 ms (12600 2xx / 3901 5xx).

After (same flags, this apply):

| Stack | GET req/s | GET latency | GET 2xx/5xx | POST req/s | POST latency | POST 2xx/5xx |
| --- | --- | --- | --- | --- | --- | --- |
| apache-whoami | 4999.25 | 10.00 ms | 74956 / 67 | 1149.90 | 43.44 ms | 12299 / 4995 |
| nginx-whoami | 3989.81 | 12.52 ms | 59894 / 0 | 1947.69 | 25.66 ms | 27451 / 1802 |
| apache-drain | 5211.54 | 9.60 ms | 78061 / 145 | 1348.95 | 37.02 ms | 17554 / 2727 |
| nginx-drain | 3588.45 | 13.93 ms | 53862 / 0 | 2552.73 | 19.57 ms | 38341 / 0 |

Apache drain vs explore whoami: GET ~+3% (noise), POST ~+23%. Nginx drain vs nginx whoami (same session): GET −10%, POST +31% and 0 5xx. CRS still dominates; dummy hop is not the 20x in #2.

### Review metrics
| Metric | Value | Why it matters |
| --- | --- | --- |
| Specs in this PR | 1 added / 0 modified | Same list as Specs |
| Open reviewer comments walked | 0 FIX / 0 ANSWER / 0 open | Unanswered review is merge risk |
| Reviewed head | adb3e2ec373d3adb0484c87351b5bd7ad653a8bf | Card must match the branch you measured |

### Stored data model
None.

### Technical review
Best possible solution vs main: inspect-only overlay for demo/drain; keep whoami stacks so #2-style bombardier can compare origins. Nginx drain is a loopback `server` after `proxy_pass` (`max_ranges 0`), not `return` on CRS `location /` (measured skip) and not serial `nc`.

Do we have a high-confidence way to reproduce? Yes — Pester `Allow-path throughput` plus `./Test-Integration.ps1 -AllStacks`.

Is this the best way to solve the issue? Yes vs DestBranch: overlay only, no plugin change, four-stack compare kept.

### Evidence
What I checked:
- nginx-drain and apache-drain smoke: GET 200, Range 200, URI 403, POST 200, POST SQLi 403, no dummy
- `./Test-Integration.ps1 -AllStacks` main Pester file: 0 failed on all four
- BENCH lines above (bombardier `-c 50 -d 15s`)
- Upstream [acouvreur#2](https://github.com/acouvreur/traefik-modsecurity-plugin/issues/2) cited as the performance issue this measurement family belongs to

### Rank-up moves
- Absolute GET RPS on nginx-drain was slightly below nginx-whoami; treat as noise unless a second run repeats it.
